### PR TITLE
Shared behaviour for tree-type structs

### DIFF
--- a/lib/satie.ex
+++ b/lib/satie.ex
@@ -33,4 +33,24 @@ defmodule Satie do
         {:error, "#{inspect(content)} cannot be formatted in Lilypond"}
     end
   end
+
+  def append(%{contents: _}, [_ | _] = list) do
+    {:error, :cannot_append_by_list, list}
+  end
+
+  def append(%{contents: contents} = container, elem) do
+    %{container | contents: List.insert_at(contents, -1, elem)}
+  end
+
+  def append(x, _), do: {:error, :cannot_append_to_non_container, x}
+
+  def extend(%{contents: contents} = container, [_ | _] = list) do
+    %{container | contents: contents ++ list}
+  end
+
+  def extend(%{contents: _}, x) do
+    {:error, :cannot_extend_by_single_element, x}
+  end
+
+  def extend(x, _), do: {:error, :cannot_extend_a_non_container, x}
 end

--- a/lib/satie/container.ex
+++ b/lib/satie/container.ex
@@ -1,6 +1,8 @@
 defmodule Satie.Container do
   defstruct [:contents]
 
+  use Satie.Tree
+
   def new(contents \\ []) when is_list(contents) do
     with {:ok, contents} <- validate_contents(contents) do
       %__MODULE__{contents: contents}

--- a/lib/satie/measure.ex
+++ b/lib/satie/measure.ex
@@ -1,6 +1,8 @@
 defmodule Satie.Measure do
   defstruct [:time_signature, :contents]
 
+  use Satie.Tree
+
   alias Satie.TimeSignature
 
   def new(time_signature, contents \\ [])

--- a/lib/satie/score.ex
+++ b/lib/satie/score.ex
@@ -1,6 +1,8 @@
 defmodule Satie.Score do
   defstruct [:contents, :name, :simultaneous]
 
+  use Satie.Tree
+
   def new(contents \\ [], opts \\ []) do
     with {:ok, contents} <- validate_contents(contents) do
       %__MODULE__{

--- a/lib/satie/staff.ex
+++ b/lib/satie/staff.ex
@@ -1,6 +1,8 @@
 defmodule Satie.Staff do
   defstruct [:contents, :name, :simultaneous]
 
+  use Satie.Tree
+
   def new(contents \\ [], opts \\ []) do
     with {:ok, contents} <- validate_contents(contents) do
       %__MODULE__{

--- a/lib/satie/staff_group.ex
+++ b/lib/satie/staff_group.ex
@@ -1,6 +1,8 @@
 defmodule Satie.StaffGroup do
   defstruct [:contents, :name, :simultaneous]
 
+  use Satie.Tree
+
   def new(contents \\ [], opts \\ []) do
     with {:ok, contents} <- validate_contents(contents) do
       %__MODULE__{

--- a/lib/satie/tree.ex
+++ b/lib/satie/tree.ex
@@ -1,0 +1,8 @@
+defmodule Satie.Tree do
+  defmacro __using__(_) do
+    quote do
+      use Satie.Tree.Access
+      use Satie.Tree.Enumerable
+    end
+  end
+end

--- a/lib/satie/tree/access.ex
+++ b/lib/satie/tree/access.ex
@@ -1,0 +1,64 @@
+defmodule Satie.Tree.Access do
+  defmacro __using__(_) do
+    quote do
+      @behaviour Access
+
+      def fetch(%__MODULE__{contents: contents}, key) do
+        case find(contents, key) do
+          nil -> :error
+          value -> {:ok, value}
+        end
+      end
+
+      def get_and_update(%__MODULE__{contents: contents} = container, key, func) do
+        case fetch(container, key) do
+          :error ->
+            {nil, container}
+
+          {:ok, current} ->
+            index = find_index(contents, key)
+
+            case func.(current) do
+              {get, update} ->
+                new_contents = List.replace_at(contents, index, update)
+                {get, %{container | contents: new_contents}}
+
+              :pop ->
+                new_contents = List.delete_at(contents, index)
+                {current, %{container | contents: new_contents}}
+            end
+        end
+      end
+
+      def pop(%__MODULE__{contents: contents} = container, key) do
+        case fetch(container, key) do
+          :error ->
+            {nil, container}
+
+          {:ok, current} ->
+            index = find_index(contents, key)
+            new_contents = List.delete_at(contents, index)
+            {current, %{container | contents: new_contents}}
+        end
+      end
+
+      defp find(contents, index) when is_integer(index), do: Enum.at(contents, index)
+
+      defp find(contents, name) when is_bitstring(name) do
+        Enum.find(contents, fn
+          %{name: ^name} -> true
+          _ -> false
+        end)
+      end
+
+      defp find_index(_contents, index) when is_integer(index), do: index
+
+      defp find_index(contents, name) when is_bitstring(name) do
+        Enum.find_index(contents, fn
+          %{name: ^name} -> true
+          _ -> false
+        end)
+      end
+    end
+  end
+end

--- a/lib/satie/tree/enumerable.ex
+++ b/lib/satie/tree/enumerable.ex
@@ -1,0 +1,34 @@
+defmodule Satie.Tree.Enumerable do
+  defmacro __using__(_) do
+    quote do
+      defimpl Enumerable do
+        def count(%@for{contents: contents}), do: {:ok, length(contents)}
+
+        def member?(%@for{contents: contents}, elem), do: {:ok, elem in contents}
+
+        def reduce(%@for{} = _tree, {:halt, acc}, _fun), do: {:halted, acc}
+
+        def reduce(%@for{} = tree, {:suspend, acc}, fun),
+          do: {:suspended, acc, &reduce(tree, &1, fun)}
+
+        def reduce(%@for{contents: []}, {:cont, acc}, _fun), do: {:done, acc}
+
+        def reduce(%@for{contents: [head | tail]} = tree, {:cont, acc}, fun) do
+          reduce(%@for{tree | contents: tail}, fun.(head, acc), fun)
+        end
+
+        if Version.compare(System.version(), "1.14.0") == :lt do
+          def slice(%@for{contents: contents} = tree) do
+            {:ok, len} = count(tree)
+            {:ok, len, &Enumerable.List.slice(contents, &1, &2, len)}
+          end
+        else
+          def slice(%@for{contents: contents} = tree) do
+            {:ok, len} = count(tree)
+            {:ok, len, & &1.contents}
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/satie/tuplet.ex
+++ b/lib/satie/tuplet.ex
@@ -1,6 +1,8 @@
 defmodule Satie.Tuplet do
   defstruct [:multiplier, :contents]
 
+  use Satie.Tree
+
   alias Satie.Multiplier
 
   def new(multiplier, contents \\ [])

--- a/lib/satie/voice.ex
+++ b/lib/satie/voice.ex
@@ -1,6 +1,8 @@
 defmodule Satie.Voice do
   defstruct [:contents, :simultaneous, :name]
 
+  use Satie.Tree
+
   def new(contents \\ [], opts \\ []) do
     with {:ok, contents} <- validate_contents(contents) do
       %__MODULE__{

--- a/test/satie/container_test.exs
+++ b/test/satie/container_test.exs
@@ -94,4 +94,59 @@ defmodule Satie.ContainerTest do
                |> String.trim()
     end
   end
+
+  describe "Access" do
+    setup do
+      inner =
+        Container.new([
+          Note.new("c'4"),
+          Note.new("d'4")
+        ])
+
+      container = Container.new([inner])
+
+      {:ok, container: container, inner: inner}
+    end
+
+    test "[]", %{container: container, inner: inner} do
+      assert container[0] == inner
+
+      assert container[0][1] == Note.new("d'4")
+
+      refute container[0][2]
+    end
+
+    test "update_in", %{container: container} do
+      new_container =
+        update_in(container, [0], fn inner ->
+          new_contents =
+            Enum.map(inner.contents, fn note ->
+              %{note | written_duration: Satie.Duration.new(1, 8)}
+            end)
+
+          %{inner | contents: new_contents}
+        end)
+
+      assert new_container ==
+               Container.new([
+                 Container.new([
+                   Note.new("c'8"),
+                   Note.new("d'8")
+                 ])
+               ])
+    end
+
+    test "pop", %{container: container} do
+      {old_note, new_container} = pop_in(container, [0, 1])
+
+      assert old_note == Note.new("d'4")
+
+      assert new_container ==
+               Container.new([
+                 Container.new([
+                   Note.new("c'4")
+                 ])
+               ])
+    end
+  end
 end

--- a/test/satie/staff_group_test.exs
+++ b/test/satie/staff_group_test.exs
@@ -126,4 +126,93 @@ defmodule Satie.StaffGroupTest do
                |> String.trim()
     end
   end
+
+  describe "append/2" do
+    test "adds a single element to the end of a staff group" do
+      staff_group =
+        StaffGroup.new(
+          [
+            Staff.new([Note.new("c'4")], name: "Violin One"),
+            Staff.new([Note.new("d'4")], name: "Violin Two"),
+            Staff.new([Note.new("e'4")], name: "Viola")
+          ],
+          name: "Strings"
+        )
+
+      staff = Staff.new([Note.new("f'4")], name: "Cello")
+
+      staff_group = Satie.append(staff_group, staff)
+
+      assert length(staff_group.contents) == 4
+    end
+
+    test "cannot append a list" do
+      staff_group =
+        StaffGroup.new(
+          [
+            Staff.new([Note.new("c'4")], name: "Violin One"),
+            Staff.new([Note.new("d'4")], name: "Violin Two"),
+            Staff.new([Note.new("e'4")], name: "Viola")
+          ],
+          name: "Strings"
+        )
+
+      staff = Staff.new([Note.new("f'4")], name: "Cello")
+
+      assert Satie.append(staff_group, [staff]) == {:error, :cannot_append_by_list, [staff]}
+    end
+
+    test "cannot append to a non-tree-type" do
+      note = Note.new("c'4")
+
+      assert Satie.append(note, Note.new("d'4")) ==
+               {:error, :cannot_append_to_non_container, note}
+    end
+  end
+
+  describe "extend/2" do
+    test "adds a list to the end of a staff group" do
+      staff_group =
+        StaffGroup.new(
+          [
+            Staff.new([Note.new("c'4")], name: "Violin One"),
+            Staff.new([Note.new("d'4")], name: "Violin Two"),
+            Staff.new([Note.new("e'4")], name: "Viola")
+          ],
+          name: "Strings"
+        )
+
+      new_staves = [
+        Staff.new([Note.new("f'4")], name: "Cello"),
+        Staff.new([Note.new("f,4")], name: "Contrabass")
+      ]
+
+      staff_group = Satie.extend(staff_group, new_staves)
+
+      assert length(staff_group.contents) == 5
+    end
+
+    test "cannot extend by a single element" do
+      staff_group =
+        StaffGroup.new(
+          [
+            Staff.new([Note.new("c'4")], name: "Violin One"),
+            Staff.new([Note.new("d'4")], name: "Violin Two"),
+            Staff.new([Note.new("e'4")], name: "Viola")
+          ],
+          name: "Strings"
+        )
+
+      staff = Staff.new([Note.new("f'4")], name: "Cello")
+
+      assert Satie.extend(staff_group, staff) == {:error, :cannot_extend_by_single_element, staff}
+    end
+
+    test "cannot extend to a non-tree-type" do
+      note = Note.new("c'4")
+
+      assert Satie.extend(note, [Note.new("d'4")]) ==
+               {:error, :cannot_extend_a_non_container, note}
+    end
+  end
 end

--- a/test/satie/staff_test.exs
+++ b/test/satie/staff_test.exs
@@ -1,7 +1,7 @@
 defmodule Satie.StaffTest do
   use ExUnit.Case, async: true
 
-  alias Satie.{Container, Note, Staff}
+  alias Satie.{Container, Note, Staff, Voice}
 
   describe "new/1" do
     test "by default a staff has no name and is sequential" do
@@ -147,6 +147,93 @@ defmodule Satie.StaffTest do
                >>
                """
                |> String.trim()
+    end
+  end
+
+  describe "Access" do
+    setup do
+      staff =
+        Staff.new([
+          Voice.new(
+            [Note.new("c'4"), Note.new("d'4")],
+            name: "Voice One"
+          ),
+          Voice.new(
+            [Note.new("e'4"), Note.new("f'4")],
+            name: "Voice Two"
+          )
+        ])
+
+      {:ok, staff: staff}
+    end
+
+    test "[] works with indices", %{staff: staff} do
+      assert staff[1][0] == Note.new("e'4")
+    end
+
+    test "[] works with named trees", %{staff: staff} do
+      assert staff["Voice One"][1] == Note.new("d'4")
+    end
+
+    test "update_in works with indices", %{staff: staff} do
+      new_staff =
+        update_in(staff, [1], fn _voice ->
+          Voice.new([Note.new("bqf2")], name: "New Voice Two")
+        end)
+
+      assert new_staff ==
+               Staff.new([
+                 Voice.new(
+                   [Note.new("c'4"), Note.new("d'4")],
+                   name: "Voice One"
+                 ),
+                 Voice.new(
+                   [Note.new("bqf2")],
+                   name: "New Voice Two"
+                 )
+               ])
+    end
+
+    test "update_in works with named trees", %{staff: staff} do
+      new_staff =
+        update_in(staff, ["Voice Two"], fn _voice ->
+          Voice.new([Note.new("bqf2")], name: "New Voice Two")
+        end)
+
+      assert new_staff[1] ==
+               Voice.new(
+                 [Note.new("bqf2")],
+                 name: "New Voice Two"
+               )
+    end
+
+    test "pop with indices", %{staff: staff} do
+      {old_note, new_staff} = pop_in(staff, [0, 0])
+
+      assert old_note == Note.new("c'4")
+
+      assert new_staff[0] ==
+               Voice.new(
+                 [
+                   Note.new("d'4")
+                 ],
+                 name: "Voice One"
+               )
+    end
+
+    test "pop with named trees", %{staff: staff} do
+      {old_voice, new_staff} = pop_in(staff, ["Voice One"])
+
+      assert old_voice.name == "Voice One"
+
+      assert new_staff[0] ==
+               Voice.new(
+                 [
+                   Note.new("e'4"),
+                   Note.new("f'4")
+                 ],
+                 name: "Voice Two"
+               )
     end
   end
 end


### PR DESCRIPTION
Implement shared behaviour for tree-type structs (Tuplet, Container, Measure, Voice, Staff, StaffGroup, Score)

* Add `Satie.Tree` that can be `use`d
* Implement `Access` by integer index and name
* Implement `Enumerable`
* Add `Satie.append/2` and `Satie.extend/2`
