### PR TITLE
Implement `Collectable` for tree-like structs

### DIFF
--- a/lib/satie.ex
+++ b/lib/satie.ex
@@ -53,4 +53,10 @@ defmodule Satie do
   end
 
   def extend(x, _), do: {:error, :cannot_extend_a_non_container, x}
+
+  def empty(%{contents: _} = tree) do
+    %{tree | contents: []}
+  end
+
+  def empty(x), do: {:error, :cannot_empty_non_tree, x}
 end

--- a/lib/satie/tree.ex
+++ b/lib/satie/tree.ex
@@ -3,6 +3,7 @@ defmodule Satie.Tree do
     quote do
       use Satie.Tree.Access
       use Satie.Tree.Enumerable
+      use Satie.Tree.Collectable
     end
   end
 end

--- a/lib/satie/tree/collectable.ex
+++ b/lib/satie/tree/collectable.ex
@@ -1,0 +1,22 @@
+defmodule Satie.Tree.Collectable do
+  defmacro __using__(_) do
+    quote do
+      defimpl Collectable do
+        def into(%@for{} = tree) do
+          fun = fn
+            tree, {:cont, elem} ->
+              Satie.append(tree, elem)
+
+            tree, :done ->
+              tree
+
+            _tree, :halt ->
+              :ok
+          end
+
+          {tree, fun}
+        end
+      end
+    end
+  end
+end

--- a/test/satie/voice_test.exs
+++ b/test/satie/voice_test.exs
@@ -1,7 +1,7 @@
 defmodule Satie.VoiceTest do
   use ExUnit.Case, async: true
 
-  alias Satie.{Container, Note, Voice}
+  alias Satie.{Container, Duration, Note, Voice}
 
   describe "new/1" do
     test "by default a voice has no name and is sequential" do
@@ -146,6 +146,21 @@ defmodule Satie.VoiceTest do
                >>
                """
                |> String.trim()
+    end
+  end
+
+  describe "Collectable" do
+    test "can combine Enum and Collectable to modify a tree 'in place'" do
+      voice = Voice.new([Note.new("c'4"), Note.new("f'4")], simultaneous: true, name: "Voice One")
+
+      voice =
+        Enum.map(voice, fn note ->
+          %{note | written_duration: Duration.new(1, 8)}
+        end)
+        |> Enum.into(Satie.empty(voice))
+
+      assert voice ==
+               Voice.new([Note.new("c'8"), Note.new("f'8")], simultaneous: true, name: "Voice One")
     end
   end
 end

--- a/test/satie_test.exs
+++ b/test/satie_test.exs
@@ -2,7 +2,7 @@ defmodule SatieTest do
   use ExUnit.Case, async: true
   import ExUnit.CaptureIO
 
-  alias Satie.Note
+  alias Satie.{Note, Voice}
 
   describe "show/1" do
     test "returns an error if the input is not a lilypondable object" do
@@ -33,6 +33,18 @@ defmodule SatieTest do
         end)
 
       assert Regex.match?(~r/#{Satie.lilypond_executable()} -o (.*) \1\.ly\nopen \1\.pdf/, output)
+    end
+  end
+
+  describe "empty/1" do
+    test "returns a container with its contents cleared but all other configuration in place" do
+      voice = Voice.new([Note.new("c'4"), Note.new("e'4")], name: "Voice One", simultaneous: true)
+
+      assert Satie.empty(voice) == Voice.new([], name: "Voice One", simultaneous: true)
+    end
+
+    test "returns an error tuple when passed a non-tree-type struct" do
+      assert Satie.empty(Note.new("c'4")) == {:error, :cannot_empty_non_tree, Note.new("c'4")}
     end
   end
 end


### PR DESCRIPTION
Implement `Collectable` protocol for tree-type structs

* Add `Satie.empty/1` as a shorthand for emptying a tree's `contents`
  field
