### PR TITLE
Fix Timespan.xor and TimespanList.xor to account for timespans that begin or end simultaneously

### DIFF
--- a/lib/satie/timespan.ex
+++ b/lib/satie/timespan.ex
@@ -313,6 +313,7 @@ defmodule Satie.Timespan do
         Timespan.new(start_offset1, start_offset2),
         Timespan.new(stop_offset1, stop_offset2)
       ]
+      |> Enum.filter(&well_formed?/1)
       |> Enum.sort_by(&to_float_pair/1)
       |> TimespanList.new()
     end

--- a/lib/satie/timespan_list.ex
+++ b/lib/satie/timespan_list.ex
@@ -161,6 +161,8 @@ defmodule Satie.TimespanList do
       calc_fragments(timespan1, timespans)
     end)
     |> List.flatten()
+    |> Enum.uniq()
+    |> Enum.filter(&Timespan.well_formed?/1)
     |> Enum.sort_by(&Timespan.to_float_pair/1)
     |> new()
   end

--- a/test/satie/timespan_list_test.exs
+++ b/test/satie/timespan_list_test.exs
@@ -385,6 +385,26 @@ defmodule Satie.TimespanListTest do
                  Timespan.new(8, 10)
                ])
     end
+
+    test "a timespan list where timespans begin or end at the same time only returns one timespan" do
+      timespan_list =
+        TimespanList.new([
+          Timespan.new(0, 10),
+          Timespan.new(0, 5),
+          Timespan.new(0, 3)
+        ])
+
+      assert TimespanList.xor(timespan_list) == TimespanList.new([Timespan.new(5, 10)])
+
+      timespan_list =
+        TimespanList.new([
+          Timespan.new(0, 10),
+          Timespan.new(5, 10),
+          Timespan.new(3, 10)
+        ])
+
+      assert TimespanList.xor(timespan_list) == TimespanList.new([Timespan.new(0, 3)])
+    end
   end
 
   describe inspect(&Satie.ToLilypond.to_lilypond/1) do

--- a/test/satie/timespan_test.exs
+++ b/test/satie/timespan_test.exs
@@ -231,11 +231,13 @@ defmodule Satie.TimespanTest do
   end
 
   describe inspect(&Timespan.xor/1) do
-    test "returns both timespans if they do not overlap" do
+    test "returns the non-overlapping portions of two timespans" do
       timespan1 = Timespan.new(0, 10)
       timespan2 = Timespan.new(5, 12)
       timespan3 = Timespan.new(-2, 2)
       timespan4 = Timespan.new(10, 20)
+
+      assert Timespan.xor(timespan1, timespan1) == TimespanList.new()
 
       assert Timespan.xor(timespan1, timespan2) ==
                TimespanList.new([Timespan.new(0, 5), Timespan.new(10, 12)])
@@ -272,6 +274,30 @@ defmodule Satie.TimespanTest do
 
       assert Timespan.xor(timespan4, timespan3) ==
                TimespanList.new([Timespan.new(-2, 2), Timespan.new(10, 20)])
+    end
+
+    test "only returns one timespan if the timespans begin or end together" do
+      timespan1 = Timespan.new(0, 10)
+      timespan2 = Timespan.new(0, 5)
+      timespan3 = Timespan.new(4, 10)
+
+      assert Timespan.xor(timespan1, timespan2) == TimespanList.new([Timespan.new(5, 10)])
+      assert Timespan.xor(timespan1, timespan3) == TimespanList.new([Timespan.new(0, 4)])
+
+      assert Timespan.xor(timespan2, timespan1) == TimespanList.new([Timespan.new(5, 10)])
+
+      assert Timespan.xor(timespan3, timespan1) == TimespanList.new([Timespan.new(0, 4)])
+    end
+
+    test "returns two parts if one timespan is entirle contained by the other" do
+      timespan1 = Timespan.new(0, 10)
+      timespan2 = Timespan.new(2, 8)
+
+      assert Timespan.xor(timespan1, timespan2) ==
+               TimespanList.new([Timespan.new(0, 2), Timespan.new(8, 10)])
+
+      assert Timespan.xor(timespan2, timespan1) ==
+               TimespanList.new([Timespan.new(0, 2), Timespan.new(8, 10)])
     end
   end
 


### PR DESCRIPTION
Fix Timespan.xor and TimespanList.xor to account for timespans that begin or end simultaneously