### PR TITLE
Reimplement attachments

### DIFF
--- a/lib/satie/articulation.ex
+++ b/lib/satie/articulation.ex
@@ -2,9 +2,9 @@ defmodule Satie.Articulation do
   @moduledoc """
   Models an articulation
   """
-  defstruct [:name]
 
-  use Satie.Attachable
+  use Satie.Attachable,
+    fields: [:name]
 
   @doc """
 
@@ -13,13 +13,12 @@ defmodule Satie.Articulation do
 
   """
   def new(name) do
-    %__MODULE__{name: name}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{name: name}) do
-      "\\#{name}"
-    end
+    %__MODULE__{
+      name: name,
+      components: [
+        after: ["\\#{name}"]
+      ]
+    }
   end
 
   defimpl Inspect do
@@ -31,12 +30,6 @@ defmodule Satie.Articulation do
         name,
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = articulation, _opts) do
-      to_string(articulation)
     end
   end
 end

--- a/lib/satie/attachable.ex
+++ b/lib/satie/attachable.ex
@@ -14,9 +14,12 @@ defmodule Satie.Attachable do
   defmacro __using__(opts) do
     location = Keyword.get(opts, :location, :after)
     priority = Keyword.get(opts, :priority, 0)
+    fields = Keyword.get(opts, :fields, [])
     has_direction = Keyword.get(opts, :has_direction, true)
 
     quote do
+      defstruct [unquote_splicing(fields), :components]
+
       defimpl Satie.IsAttachable do
         def attachable?(_), do: true
 

--- a/lib/satie/barline.ex
+++ b/lib/satie/barline.ex
@@ -3,18 +3,15 @@ defmodule Satie.Barline do
     models a barline
   """
 
-  defstruct [:symbol]
-
-  use Satie.Attachable, priority: 10, has_direction: false
+  use Satie.Attachable, fields: [:symbol], priority: 10, has_direction: false
 
   def new(symbol) when is_bitstring(symbol) do
-    %__MODULE__{symbol: symbol}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{symbol: symbol}) do
-      "\\bar #{inspect(symbol)}"
-    end
+    %__MODULE__{
+      symbol: symbol,
+      components: [
+        after: ["\\bar #{inspect(symbol)}"]
+      ]
+    }
   end
 
   defimpl Inspect do
@@ -23,15 +20,9 @@ defmodule Satie.Barline do
     def inspect(%@for{symbol: symbol}, _opts) do
       concat([
         "#Satie.Barline<",
-        symbol,
+        "#{inspect(symbol)}",
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{symbol: symbol}, _opts) do
-      "\\bar #{inspect(symbol)}"
     end
   end
 end

--- a/lib/satie/breath_mark.ex
+++ b/lib/satie/breath_mark.ex
@@ -3,9 +3,7 @@ defmodule Satie.BreathMark do
   Models a breath mark
   """
 
-  defstruct []
-
-  use Satie.Attachable
+  use Satie.Attachable, has_direction: false
 
   @doc """
 
@@ -14,13 +12,11 @@ defmodule Satie.BreathMark do
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}) do
-      "\\breathe"
-    end
+    %__MODULE__{
+      components: [
+        after: ["\\breathe"]
+      ]
+    }
   end
 
   defimpl Inspect do
@@ -31,12 +27,6 @@ defmodule Satie.BreathMark do
         "#Satie.BreathMark<",
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = breath_mark, _opts) do
-      to_string(breath_mark)
     end
   end
 end

--- a/lib/satie/chord.ex
+++ b/lib/satie/chord.ex
@@ -38,7 +38,7 @@ defmodule Satie.Chord do
     import Satie.Lilypond.OutputHelpers
 
     def to_lilypond(%@for{noteheads: noteheads, written_duration: duration} = chord, _opts) do
-      {attachments_before, attachments_after} = attachments_to_lilypond(chord)
+      %{before: attachments_before, after: attachments_after} = attachments_to_lilypond(chord)
 
       [
         attachments_before,

--- a/lib/satie/clef.ex
+++ b/lib/satie/clef.ex
@@ -3,16 +3,17 @@ defmodule Satie.Clef do
   Models a musical clef
   """
 
-  defstruct [:name]
-
-  use Satie.Attachable, location: :before, has_direction: false
+  use Satie.Attachable, fields: [:name], location: :before, has_direction: false
 
   def new(name) do
-    %__MODULE__{name: name}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{name: name}), do: name
+    %__MODULE__{
+      name: name,
+      components: [
+        before: [
+          "\\clef #{inspect(name)}"
+        ]
+      ]
+    }
   end
 
   defimpl Inspect do
@@ -24,12 +25,6 @@ defmodule Satie.Clef do
         name,
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{name: name}, _opts) do
-      ~s(\\clef "#{name}")
     end
   end
 end

--- a/lib/satie/dynamic.ex
+++ b/lib/satie/dynamic.ex
@@ -3,44 +3,34 @@ defmodule Satie.Dynamic do
   Models a static dynamic
   """
 
-  defstruct [:name]
-
-  use Satie.Attachable
+  use Satie.Attachable, fields: [:dynamic]
 
   @doc """
 
       iex> Dynamic.new("ff")
-      #Satie.Dynamic<\\ff>
-
-      iex> Dynamic.new("ppp")
-      #Satie.Dynamic<\\ppp>
+      #Satie.Dynamic<ff>
 
   """
-  def new(name) do
-    %__MODULE__{name: name}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{name: name}) do
-      "\\#{name}"
-    end
+  def new(dynamic) do
+    %__MODULE__{
+      dynamic: dynamic,
+      components: [
+        after: [
+          "\\#{dynamic}"
+        ]
+      ]
+    }
   end
 
   defimpl Inspect do
     import Inspect.Algebra
 
-    def inspect(%@for{} = dynamic, _opts) do
+    def inspect(%@for{dynamic: dynamic}, _opts) do
       concat([
         "#Satie.Dynamic<",
-        to_string(dynamic),
+        dynamic,
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = dynamic, _opts) do
-      to_string(dynamic)
     end
   end
 end

--- a/lib/satie/fermata.ex
+++ b/lib/satie/fermata.ex
@@ -3,49 +3,42 @@ defmodule Satie.Fermata do
   Models a fermata
   """
 
-  defstruct [:length]
-
-  use Satie.Attachable
+  use Satie.Attachable, fields: [:length]
 
   @valid_lengths ~w(veryshort short fermata long verylong)a
 
   @doc """
 
       iex> Fermata.new()
-      #Satie.Fermata<\\fermata>
+      #Satie.Fermata<fermata>
 
       iex> Fermata.new(:short)
-      #Satie.Fermata<\\shortfermata>
+      #Satie.Fermata<shortfermata>
 
   """
   def new(length \\ :fermata) when length in @valid_lengths do
-    %__MODULE__{length: length}
+    %__MODULE__{
+      length: length,
+      components: [
+        after: [
+          "\\#{_symbol_from_length(length)}"
+        ]
+      ]
+    }
   end
 
-  defimpl String.Chars do
-    def to_string(%@for{length: length}) do
-      "\\#{command_from_length(length)}"
-    end
-
-    defp command_from_length(:fermata), do: "fermata"
-    defp command_from_length(command), do: "#{command}fermata"
-  end
+  def _symbol_from_length(:fermata), do: "fermata"
+  def _symbol_from_length(length), do: "#{length}fermata"
 
   defimpl Inspect do
     import Inspect.Algebra
 
-    def inspect(%@for{} = fermata, _opts) do
+    def inspect(%@for{length: length}, _opts) do
       concat([
         "#Satie.Fermata<",
-        to_string(fermata),
+        @for._symbol_from_length(length),
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = fermata, _opts) do
-      to_string(fermata)
     end
   end
 end

--- a/lib/satie/key_signature.ex
+++ b/lib/satie/key_signature.ex
@@ -2,9 +2,12 @@ defmodule Satie.KeySignature do
   @moduledoc """
   Models a key signature
   """
-  defstruct [:pitch_class, :mode]
 
-  use Satie.Attachable, location: :before, priority: 1, has_direction: false
+  use Satie.Attachable,
+    fields: [:pitch_class, :mode],
+    location: :before,
+    priority: 1,
+    has_direction: false
 
   alias Satie.PitchClass
 
@@ -21,9 +24,17 @@ defmodule Satie.KeySignature do
 
   """
   def new(pitch_class, mode \\ :major) do
-    with {:ok, pitch_class} <- validate_pitch_class(pitch_class),
+    with {:ok, pc} <- validate_pitch_class(pitch_class),
          {:ok, mode} <- validate_mode(mode) do
-      %__MODULE__{pitch_class: pitch_class, mode: mode}
+      %__MODULE__{
+        pitch_class: pc,
+        mode: mode,
+        components: [
+          before: [
+            "\\key #{pc.name} \\#{mode}"
+          ]
+        ]
+      }
     end
   end
 
@@ -38,32 +49,15 @@ defmodule Satie.KeySignature do
   defp validate_mode(mode) when mode in @valid_modes, do: {:ok, mode}
   defp validate_mode(mode), do: {:error, :invalid_mode, mode}
 
-  defimpl String.Chars do
-    def to_string(%@for{pitch_class: pitch_class, mode: mode}) do
-      pitch_class.name <> " " <> Kernel.to_string(mode)
-    end
-  end
-
   defimpl Inspect do
     import Inspect.Algebra
 
-    def inspect(%@for{} = key_signature, _opts) do
+    def inspect(%@for{pitch_class: pc, mode: mode}, _opts) do
       concat([
         "#Satie.KeySignature<",
-        to_string(key_signature),
+        "#{pc.name} #{mode}",
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{pitch_class: pitch_class, mode: mode}, _opts) do
-      [
-        "\\key",
-        pitch_class.name,
-        "\\#{mode}"
-      ]
-      |> Enum.join(" ")
     end
   end
 end

--- a/lib/satie/laissez_vibrer.ex
+++ b/lib/satie/laissez_vibrer.ex
@@ -3,8 +3,6 @@ defmodule Satie.LaissezVibrer do
   Models a laissez vibrer tie
   """
 
-  defstruct []
-
   use Satie.Attachable
 
   @doc """
@@ -14,13 +12,13 @@ defmodule Satie.LaissezVibrer do
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}) do
-      "\\laissezVibrer"
-    end
+    %__MODULE__{
+      components: [
+        after: [
+          "\\laissezVibrer"
+        ]
+      ]
+    }
   end
 
   defimpl Inspect do
@@ -31,12 +29,6 @@ defmodule Satie.LaissezVibrer do
         "#Satie.LaissezVibrer<",
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = laissez_vibrer, _opts) do
-      to_string(laissez_vibrer)
     end
   end
 end

--- a/lib/satie/multi_measure_rest.ex
+++ b/lib/satie/multi_measure_rest.ex
@@ -8,6 +8,7 @@ defmodule Satie.MultiMeasureRest do
 
   @re ~r/^(R1\s*\*\s*)?(?<time_signature>\d+\/\d+)\s*\*\s*(?<measures>\d+)$/
 
+  # TODO: use a multiplier instead of a time signature?
   def new(multi_measure_rest) when is_bitstring(multi_measure_rest) do
     case Regex.named_captures(@re, multi_measure_rest) do
       %{"time_signature" => time_sig, "measures" => measures} ->

--- a/lib/satie/note.ex
+++ b/lib/satie/note.ex
@@ -32,7 +32,7 @@ defmodule Satie.Note do
     import Satie.Lilypond.OutputHelpers
 
     def to_lilypond(%@for{} = note, _opts) do
-      {attachments_before, attachments_after} = attachments_to_lilypond(note)
+      %{before: attachments_before, after: attachments_after} = attachments_to_lilypond(note)
 
       [
         attachments_before,

--- a/lib/satie/ottava.ex
+++ b/lib/satie/ottava.ex
@@ -3,21 +3,20 @@ defmodule Satie.Ottava do
     Models an ottava setting
   """
 
-  defstruct [:degree]
-
-  use Satie.Attachable, has_direction: false
+  use Satie.Attachable, fields: [:degree], location: :before, has_direction: false
 
   def new(degree) when is_integer(degree) do
-    %__MODULE__{degree: degree}
+    %__MODULE__{
+      degree: degree,
+      components: [
+        before: [
+          "\\ottava ##{degree}"
+        ]
+      ]
+    }
   end
 
   def new(degree), do: {:error, :ottava_new, degree}
-
-  defimpl String.Chars do
-    def to_string(%@for{degree: degree}) do
-      "\\ottava ##{degree}"
-    end
-  end
 
   defimpl Inspect do
     import Inspect.Algebra
@@ -28,12 +27,6 @@ defmodule Satie.Ottava do
         inspect(degree),
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{degree: degree}, _) do
-      "\\ottava ##{degree}"
     end
   end
 end

--- a/lib/satie/repeat_tie.ex
+++ b/lib/satie/repeat_tie.ex
@@ -2,7 +2,6 @@ defmodule Satie.RepeatTie do
   @moduledoc """
   Models a repeat tie
   """
-  defstruct []
 
   use Satie.Attachable
 
@@ -13,29 +12,16 @@ defmodule Satie.RepeatTie do
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}) do
-      "\\repeatTie"
-    end
+    %__MODULE__{
+      components: [
+        after: ["\\repeatTie"]
+      ]
+    }
   end
 
   defimpl Inspect do
-    import Inspect.Algebra
-
     def inspect(%@for{}, _opts) do
-      concat([
-        "#Satie.RepeatTie<",
-        ">"
-      ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = repeat_tie, _opts) do
-      to_string(repeat_tie)
+      "#Satie.RepeatTie<>"
     end
   end
 end

--- a/lib/satie/rest.ex
+++ b/lib/satie/rest.ex
@@ -28,12 +28,12 @@ defmodule Satie.Rest do
     import Satie.Lilypond.OutputHelpers
 
     def to_lilypond(%@for{written_duration: duration} = rest, _opts) do
-      {attachments_before, attachments_after} = attachments_to_lilypond(rest)
+      %{before: attachments_before, after: attachments_after} = attachments_to_lilypond(rest)
 
       [
         attachments_before,
         "r" <> Satie.to_lilypond(duration),
-        attachments_after
+        Enum.map(attachments_after, &indent/1)
       ]
       |> List.flatten()
       |> Enum.reject(&is_nil/1)

--- a/lib/satie/spacer.ex
+++ b/lib/satie/spacer.ex
@@ -28,12 +28,12 @@ defmodule Satie.Spacer do
     import Satie.Lilypond.OutputHelpers
 
     def to_lilypond(%@for{written_duration: duration} = spacer, _opts) do
-      {attachments_before, attachments_after} = attachments_to_lilypond(spacer)
+      %{before: attachments_before, after: attachments_after} = attachments_to_lilypond(spacer)
 
       [
         attachments_before,
         "s" <> Satie.to_lilypond(duration),
-        attachments_after
+        Enum.map(attachments_after, &indent/1)
       ]
       |> List.flatten()
       |> Enum.reject(&is_nil/1)

--- a/lib/satie/start_beam.ex
+++ b/lib/satie/start_beam.ex
@@ -2,7 +2,6 @@ defmodule Satie.StartBeam do
   @moduledoc """
   Models the start of a beam
   """
-  defstruct []
 
   use Satie.Attachable
 
@@ -13,29 +12,16 @@ defmodule Satie.StartBeam do
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}) do
-      "["
-    end
+    %__MODULE__{
+      components: [
+        after: ["["]
+      ]
+    }
   end
 
   defimpl Inspect do
-    import Inspect.Algebra
-
     def inspect(%@for{}, _opts) do
-      concat([
-        "#Satie.StartBeam<",
-        ">"
-      ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = start_beam, _opts) do
-      to_string(start_beam)
+      "#Satie.StartBeam<>"
     end
   end
 end

--- a/lib/satie/start_hairpin.ex
+++ b/lib/satie/start_hairpin.ex
@@ -3,13 +3,17 @@ defmodule Satie.StartHairpin do
   Models the beginning of a hairpin
   """
 
-  defstruct [:direction]
+  use Satie.Attachable, fields: [:direction, :output]
 
-  use Satie.Attachable
+  def new(direction, opts \\ []) do
+    output = Keyword.get(opts, :output, :symbol)
 
-  def new(direction) do
     with {:ok, direction} <- validate_direction(direction) do
-      %__MODULE__{direction: direction}
+      %__MODULE__{
+        direction: direction,
+        output: output,
+        components: [after: [build_component(direction, output)]]
+      }
     end
   end
 
@@ -20,10 +24,10 @@ defmodule Satie.StartHairpin do
   defp validate_direction(decresc) when decresc in @valid_decrescendos, do: {:ok, :decrescendo}
   defp validate_direction(x), do: {:error, :start_hairpin_new, x}
 
-  defimpl String.Chars do
-    def to_string(%@for{direction: :crescendo}), do: "\\<"
-    def to_string(%@for{direction: :decrescendo}), do: "\\>"
-  end
+  defp build_component(:crescendo, :symbol), do: "\\<"
+  defp build_component(:crescendo, :text), do: "\\cresc"
+  defp build_component(:decrescendo, :symbol), do: "\\>"
+  defp build_component(:decrescendo, :text), do: "\\decresc"
 
   defimpl Inspect do
     import Inspect.Algebra
@@ -35,10 +39,5 @@ defmodule Satie.StartHairpin do
         ">"
       ])
     end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{direction: :crescendo}, _), do: "\\<"
-    def to_lilypond(%@for{direction: :decrescendo}, _), do: "\\>"
   end
 end

--- a/lib/satie/start_pedal.ex
+++ b/lib/satie/start_pedal.ex
@@ -3,16 +3,19 @@ defmodule Satie.StartPedal do
   Models a pedal down event
   """
 
-  defstruct [:pedal]
-
-  use Satie.Attachable
+  use Satie.Attachable, fields: [:pedal], has_direction: false
 
   @valid_pedals ~w(sustain sostenuto corda)a
 
   def new(pedal \\ :sustain)
 
   def new(pedal) when pedal in @valid_pedals do
-    %__MODULE__{pedal: pedal}
+    %__MODULE__{
+      pedal: pedal,
+      components: [
+        after: [_component(pedal)]
+      ]
+    }
   end
 
   def new(pedal) when is_bitstring(pedal) do
@@ -24,11 +27,9 @@ defmodule Satie.StartPedal do
 
   def new(pedal), do: {:error, :start_pedal_new, pedal}
 
-  defimpl String.Chars do
-    def to_string(%@for{pedal: :sustain}), do: "\\sustainOn"
-    def to_string(%@for{pedal: :sostenuto}), do: "\\sostenutoOn"
-    def to_string(%@for{pedal: :corda}), do: "\\unaCorda"
-  end
+  def _component(:sustain), do: "\\sustainOn"
+  def _component(:sostenuto), do: "\\sostenutoOn"
+  def _component(:corda), do: "\\unaCorda"
 
   defimpl Inspect do
     import Inspect.Algebra
@@ -40,11 +41,5 @@ defmodule Satie.StartPedal do
         ">"
       ])
     end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{pedal: :sustain}, _), do: "\\sustainOn"
-    def to_lilypond(%@for{pedal: :sostenuto}, _), do: "\\sostenutoOn"
-    def to_lilypond(%@for{pedal: :corda}, _), do: "\\unaCorda"
   end
 end

--- a/lib/satie/start_phrasing_slur.ex
+++ b/lib/satie/start_phrasing_slur.ex
@@ -3,40 +3,25 @@ defmodule Satie.StartPhrasingSlur do
   Models the beginning of a phrasing slur
   """
 
-  defstruct []
-
   use Satie.Attachable
 
   @doc """
 
-      iex> StartPhrasingSlur.new
+      iex> StartPhrasingSlur.new()
       #Satie.StartPhrasingSlur<>
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}) do
-      "\\("
-    end
+    %__MODULE__{
+      components: [
+        after: ["\\("]
+      ]
+    }
   end
 
   defimpl Inspect do
-    import Inspect.Algebra
-
     def inspect(%@for{}, _opts) do
-      concat([
-        "#Satie.StartPhrasingSlur<",
-        ">"
-      ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = start_phrasing_slur, _opts) do
-      to_string(start_phrasing_slur)
+      "#Satie.StartPhrasingSlur<>"
     end
   end
 end

--- a/lib/satie/start_slur.ex
+++ b/lib/satie/start_slur.ex
@@ -2,41 +2,26 @@ defmodule Satie.StartSlur do
   @moduledoc """
   Models the beginning of a slur
   """
-  defstruct []
 
   use Satie.Attachable
 
   @doc """
 
       iex> StartSlur.new
-      #Satie.StartSlur<(>
+      #Satie.StartSlur<>
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}) do
-      "("
-    end
+    %__MODULE__{
+      components: [
+        after: ["("]
+      ]
+    }
   end
 
   defimpl Inspect do
-    import Inspect.Algebra
-
-    def inspect(%@for{} = start_slur, _opts) do
-      concat([
-        "#Satie.StartSlur<",
-        to_string(start_slur),
-        ">"
-      ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = start_slur, _opts) do
-      to_string(start_slur)
+    def inspect(%@for{}, _opts) do
+      "#Satie.StartSlur<>"
     end
   end
 end

--- a/lib/satie/stop_beam.ex
+++ b/lib/satie/stop_beam.ex
@@ -2,9 +2,8 @@ defmodule Satie.StopBeam do
   @moduledoc """
     Models the end of a beam
   """
-  defstruct []
 
-  use Satie.Attachable, priority: -1
+  use Satie.Attachable, priority: -1, has_direction: false
 
   @doc """
 
@@ -13,25 +12,16 @@ defmodule Satie.StopBeam do
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}), do: "]"
+    %__MODULE__{
+      components: [
+        after: ["]"]
+      ]
+    }
   end
 
   defimpl Inspect do
-    import Inspect.Algebra
-
     def inspect(%@for{}, _opts) do
-      concat([
-        "#Satie.StopBeam<",
-        ">"
-      ])
+      "#Satie.StopBeam<>"
     end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = stop_beam, _opts), do: to_string(stop_beam)
   end
 end

--- a/lib/satie/stop_hairpin.ex
+++ b/lib/satie/stop_hairpin.ex
@@ -3,33 +3,24 @@ defmodule Satie.StopHairpin do
     models the end of a hairpin
   """
 
-  defstruct []
-
-  use Satie.Attachable, priority: -1
+  use Satie.Attachable, priority: -1, has_direction: false
 
   @doc """
 
       iex> StopHairpin.new()
       #Satie.StopHairpin<>
   """
-  def new, do: %__MODULE__{}
-
-  defimpl String.Chars do
-    def to_string(%@for{}), do: "\\!"
+  def new do
+    %__MODULE__{
+      components: [
+        after: ["\\!"]
+      ]
+    }
   end
 
   defimpl Inspect do
-    import Inspect.Algebra
-
     def inspect(%@for{}, _opts) do
-      concat([
-        "#Satie.StopHairpin<",
-        ">"
-      ])
+      "#Satie.StopHairpin<>"
     end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = stop_hairpin, _opts), do: to_string(stop_hairpin)
   end
 end

--- a/lib/satie/stop_pedal.ex
+++ b/lib/satie/stop_pedal.ex
@@ -3,16 +3,19 @@ defmodule Satie.StopPedal do
   Models a pedal up event
   """
 
-  defstruct [:pedal]
-
-  use Satie.Attachable
+  use Satie.Attachable, fields: [:pedal], has_direction: false
 
   @valid_pedals ~w(sustain sostenuto corda)a
 
   def new(pedal \\ :sustain)
 
   def new(pedal) when pedal in @valid_pedals do
-    %__MODULE__{pedal: pedal}
+    %__MODULE__{
+      pedal: pedal,
+      components: [
+        after: [_component(pedal)]
+      ]
+    }
   end
 
   def new(pedal) when is_bitstring(pedal) do
@@ -24,11 +27,9 @@ defmodule Satie.StopPedal do
 
   def new(pedal), do: {:error, :stop_pedal_new, pedal}
 
-  defimpl String.Chars do
-    def to_string(%@for{pedal: :sustain}), do: "\\sustainOff"
-    def to_string(%@for{pedal: :sostenuto}), do: "\\sostenutoOff"
-    def to_string(%@for{pedal: :corda}), do: "\\treCorde"
-  end
+  def _component(:sustain), do: "\\sustainOff"
+  def _component(:sostenuto), do: "\\sostenutoOff"
+  def _component(:corda), do: "\\treCorde"
 
   defimpl Inspect do
     import Inspect.Algebra
@@ -40,11 +41,5 @@ defmodule Satie.StopPedal do
         ">"
       ])
     end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{pedal: :sustain}, _), do: "\\sustainOff"
-    def to_lilypond(%@for{pedal: :sostenuto}, _), do: "\\sostenutoOff"
-    def to_lilypond(%@for{pedal: :corda}, _), do: "\\treCorde"
   end
 end

--- a/lib/satie/stop_phrasing_slur.ex
+++ b/lib/satie/stop_phrasing_slur.ex
@@ -2,9 +2,8 @@ defmodule Satie.StopPhrasingSlur do
   @moduledoc """
     Models the end of a phrasing slur
   """
-  defstruct []
 
-  use Satie.Attachable, priority: -1
+  use Satie.Attachable, priority: -1, has_direction: false
 
   @doc """
 
@@ -13,27 +12,16 @@ defmodule Satie.StopPhrasingSlur do
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}), do: "\\)"
+    %__MODULE__{
+      components: [
+        after: ["\\)"]
+      ]
+    }
   end
 
   defimpl Inspect do
-    import Inspect.Algebra
-
     def inspect(%@for{}, _opts) do
-      concat([
-        "#Satie.StopPhrasingSlur<",
-        ">"
-      ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = stop_phrasing_slur, _opts) do
-      to_string(stop_phrasing_slur)
+      "#Satie.StopPhrasingSlur<>"
     end
   end
 end

--- a/lib/satie/stop_slur.ex
+++ b/lib/satie/stop_slur.ex
@@ -3,9 +3,7 @@ defmodule Satie.StopSlur do
     Models the end of a slur
   """
 
-  defstruct []
-
-  use Satie.Attachable, priority: -1
+  use Satie.Attachable, priority: -1, has_direction: false
 
   @doc """
 
@@ -14,25 +12,16 @@ defmodule Satie.StopSlur do
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}), do: ")"
+    %__MODULE__{
+      components: [
+        after: [")"]
+      ]
+    }
   end
 
   defimpl Inspect do
-    import Inspect.Algebra
-
     def inspect(%@for{}, _opts) do
-      concat([
-        "#Satie.StopSlur<",
-        ">"
-      ])
+      "#Satie.StopSlur<>"
     end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = stop_slur, _opts), do: to_string(stop_slur)
   end
 end

--- a/lib/satie/tie.ex
+++ b/lib/satie/tie.ex
@@ -3,8 +3,6 @@ defmodule Satie.Tie do
   Models a tie
   """
 
-  defstruct []
-
   use Satie.Attachable
 
   @doc """
@@ -14,29 +12,16 @@ defmodule Satie.Tie do
 
   """
   def new do
-    %__MODULE__{}
-  end
-
-  defimpl String.Chars do
-    def to_string(%@for{}) do
-      "~"
-    end
+    %__MODULE__{
+      components: [
+        after: ["~"]
+      ]
+    }
   end
 
   defimpl Inspect do
-    import Inspect.Algebra
-
     def inspect(%@for{}, _opts) do
-      concat([
-        "#Satie.Tie<",
-        ">"
-      ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{} = tie, _opts) do
-      to_string(tie)
+      "#Satie.Tie<>"
     end
   end
 end

--- a/lib/satie/time_signature.ex
+++ b/lib/satie/time_signature.ex
@@ -2,9 +2,13 @@ defmodule Satie.TimeSignature do
   @moduledoc """
   Models a time signature
   """
-  defstruct [:numerator, :denominator]
 
-  use Satie.Attachable, location: :before, priority: 3, has_direction: false
+  # TODO: have this use a Fraction
+  use Satie.Attachable,
+    fields: [:numerator, :denominator],
+    location: :before,
+    priority: 3,
+    has_direction: false
 
   @re ~r/^(\\time\s+)?(?<numerator>\d+)\/(?<denominator>\d+)$/
 
@@ -23,15 +27,16 @@ defmodule Satie.TimeSignature do
   def new(numerator, denominator) when is_integer(numerator) and is_integer(denominator) do
     %__MODULE__{
       numerator: numerator,
-      denominator: denominator
+      denominator: denominator,
+      components: [
+        before: [
+          "\\time #{numerator}/#{denominator}"
+        ]
+      ]
     }
   end
 
   def new(numerator, denominator), do: {:error, :time_signature_new, {numerator, denominator}}
-
-  defimpl String.Chars do
-    def to_string(%@for{} = time_signature), do: Satie.to_lilypond(time_signature)
-  end
 
   defimpl Inspect do
     import Inspect.Algebra
@@ -42,12 +47,6 @@ defmodule Satie.TimeSignature do
         "#{n}/#{d}",
         ">"
       ])
-    end
-  end
-
-  defimpl Satie.ToLilypond do
-    def to_lilypond(%@for{numerator: n, denominator: d}, _opts) do
-      "\\time #{n}/#{d}"
     end
   end
 end

--- a/test/satie/articulation_test.exs
+++ b/test/satie/articulation_test.exs
@@ -1,19 +1,44 @@
 defmodule Satie.ArticulationTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.Articulation
+  alias Satie.{Articulation, Note}
 
   doctest Articulation
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of an articulation" do
-      assert Articulation.new("marcato") |> to_string() == "\\marcato"
+  describe_function &Articulation.new/1 do
+    test "creates an articulation with the correct name" do
+      assert Articulation.new("accent") == %Articulation{
+               name: "accent",
+               components: [
+                 after: [
+                   "\\accent"
+                 ]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of an articulation" do
-      assert Articulation.new("staccato") |> Satie.to_lilypond() == "\\staccato"
+  describe "attaching an articulation to a note" do
+    test "with default position" do
+      note = Note.new("c'4")
+
+      accent = Articulation.new("accent")
+      marcato = Articulation.new("marcato")
+      mordent = Articulation.new("mordent")
+
+      note = Satie.attach(note, accent)
+      note = Satie.attach(note, marcato, direction: :down)
+      note = Satie.attach(note, mordent, priority: -1, direction: :up)
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 ^ \\mordent
+                 - \\accent
+                 _ \\marcato
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/attachment_test.exs
+++ b/test/satie/attachment_test.exs
@@ -1,7 +1,7 @@
 defmodule Satie.AttachmentTest do
   use ExUnit.Case, async: true
 
-  alias Satie.{Articulation, Attachment, Clef, Note, TimeSignature}
+  alias Satie.{Articulation, Attachment}
 
   doctest Attachment
 
@@ -18,61 +18,6 @@ defmodule Satie.AttachmentTest do
       attachment = Attachment.new(Articulation.new("accent"), position: :before)
 
       assert attachment.position == :before
-    end
-  end
-
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "defaults to no direction" do
-      accent = Articulation.new("accent")
-      attachment = Attachment.new(accent)
-
-      assert Satie.to_lilypond(attachment) == "- \\accent"
-    end
-
-    test "outputs correctly for specified direction" do
-      accent = Articulation.new("accent")
-      attachment = Attachment.new(accent, direction: :down)
-
-      assert Satie.to_lilypond(attachment) == "_ \\accent"
-    end
-
-    test "no direction output for an attachment that has no direction" do
-      time_signature = TimeSignature.new(3, 4)
-      attachment = Attachment.new(time_signature)
-
-      assert Satie.to_lilypond(attachment) == "\\time 3/4"
-    end
-
-    test "with no priority, similar attachemnts are printed in the order they are added" do
-      note = Note.new("c'4")
-
-      note =
-        Satie.attach(note, Articulation.new("accent"))
-        |> Satie.attach(Articulation.new("marcato"))
-
-      assert Satie.to_lilypond(note) ==
-               """
-               c'4
-                 - \\accent
-                 - \\marcato
-               """
-               |> String.trim()
-    end
-
-    test "priority can be specified at attachment time" do
-      note = Note.new("c'4")
-
-      note =
-        Satie.attach(note, Articulation.new("accent"), priority: -1)
-        |> Satie.attach(Articulation.new("marcato"), priority: -2)
-
-      assert Satie.to_lilypond(note) ==
-               """
-               c'4
-                 - \\marcato
-                 - \\accent
-               """
-               |> String.trim()
     end
   end
 end

--- a/test/satie/barline_test.exs
+++ b/test/satie/barline_test.exs
@@ -3,33 +3,43 @@ defmodule Satie.BarlineTest do
 
   import DescribeFunction
 
-  alias Satie.Barline
+  alias Satie.{Articulation, Barline, Note}
 
   doctest Barline
 
   describe_function &Barline.new/1 do
     test "creates a barline with the given symbol input" do
       assert Barline.new("|.") == %Barline{
-               symbol: "|."
+               symbol: "|.",
+               components: [
+                 after: [
+                   "\\bar \"|.\""
+                 ]
+               ]
              }
-    end
-  end
-
-  describe_function &String.Chars.to_string/1 do
-    test "returns reasonable string output for the barline" do
-      assert Barline.new("||") |> to_string() == ~s(\\bar "||")
     end
   end
 
   describe_function &Inspect.inspect/2 do
     test "returns a barline formatted for IEx" do
-      assert Barline.new("|.|") |> inspect() == "#Satie.Barline<|.|>"
+      assert Barline.new("|.|") |> inspect() == "#Satie.Barline<\"|.|\">"
     end
   end
 
-  describe_function &Satie.ToLilypond.to_lilypond/2 do
-    test "returns the correct lilypond representation of a barline" do
-      assert Barline.new("||") |> Satie.to_lilypond() == ~s(\\bar "||")
+  describe "attaching a barline to a note" do
+    test "correctly prioritizes the barline at the end of attachments" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(Barline.new("||"))
+        |> Satie.attach(Articulation.new("accent"))
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 - \\accent
+                 \\bar "||"
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/breath_mark_test.exs
+++ b/test/satie/breath_mark_test.exs
@@ -1,19 +1,33 @@
 defmodule Satie.BreathMarkTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.BreathMark
+  alias Satie.{BreathMark, Rest}
 
   doctest BreathMark
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a breath mark" do
-      assert BreathMark.new() |> to_string() == "\\breathe"
+  describe_function &BreathMark.new/0 do
+    test "returns the correct components for the breathmark" do
+      assert BreathMark.new() == %BreathMark{
+               components: [
+                 after: ["\\breathe"]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a breath mark" do
-      assert BreathMark.new() |> Satie.to_lilypond() == "\\breathe"
+  describe "attaching a breathmark to a rest" do
+    test "returns the correct lilypond" do
+      rest =
+        Rest.new("r4")
+        |> Satie.attach(BreathMark.new())
+
+      assert Satie.to_lilypond(rest) ==
+               """
+               r4
+                 \\breathe
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/clef_test.exs
+++ b/test/satie/clef_test.exs
@@ -1,31 +1,36 @@
 defmodule Satie.ClefTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.Clef
+  alias Satie.{Clef, Note}
 
-  describe "new/1" do
+  describe_function &Clef.new/1 do
     test "creates a clef struct" do
       assert Clef.new("treble") == %Clef{
-               name: "treble"
+               name: "treble",
+               components: [before: ["\\clef \"treble\""]]
              }
     end
   end
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a clef" do
-      assert Clef.new("treble") |> to_string() == "treble"
-    end
-  end
-
-  describe inspect(&Inspect.inspect/2) do
+  describe_function &Inspect.inspect/2 do
     test "returns a clef for IEx" do
       assert Clef.new("treble") |> inspect() == "#Satie.Clef<treble>"
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a clef" do
-      assert Clef.new("treble") |> Satie.to_lilypond() == ~s(\\clef "treble")
+  describe "attaching a clef to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c4")
+        |> Satie.attach(Clef.new("bass"))
+
+      assert Satie.to_lilypond(note) ==
+               """
+               \\clef "bass"
+               c4
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/dynamic_test.exs
+++ b/test/satie/dynamic_test.exs
@@ -1,27 +1,36 @@
 defmodule Satie.DynamicTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.Dynamic
+  alias Satie.{Dynamic, Note}
 
   doctest Dynamic
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of dynamic" do
-      assert Dynamic.new("mp") |> to_string() == "\\mp"
-
-      assert Dynamic.new("f") |> to_string() == "\\f"
-
-      assert Dynamic.new("sfz") |> to_string() == "\\sfz"
+  describe_function &Dynamic.new/1 do
+    test "returns the correct components" do
+      assert Dynamic.new("mp") == %Dynamic{
+               dynamic: "mp",
+               components: [
+                 after: [
+                   "\\mp"
+                 ]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a dynamic" do
-      assert Dynamic.new("mp") |> Satie.to_lilypond() == "\\mp"
+  describe "attaching a dynamic to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(Dynamic.new("fff"))
 
-      assert Dynamic.new("f") |> Satie.to_lilypond() == "\\f"
-
-      assert Dynamic.new("sfz") |> Satie.to_lilypond() == "\\sfz"
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 - \\fff
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/fermata_test.exs
+++ b/test/satie/fermata_test.exs
@@ -1,25 +1,36 @@
 defmodule Satie.FermataTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.Fermata
+  alias Satie.{Fermata, Rest}
 
   doctest Fermata
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a fermata" do
-      assert Fermata.new() |> to_string() == "\\fermata"
-
-      assert Fermata.new(:verylong) |> to_string() == "\\verylongfermata"
-
-      assert Fermata.new(:veryshort) |> to_string() == "\\veryshortfermata"
+  describe_function &Fermata.new/1 do
+    test "returns the correct components" do
+      assert Fermata.new(:verylong) == %Fermata{
+               length: :verylong,
+               components: [
+                 after: [
+                   "\\verylongfermata"
+                 ]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a fermata" do
-      assert Fermata.new() |> Satie.to_lilypond() == "\\fermata"
+  describe "attaching a fermata to a rest" do
+    test "returns the correct lilypond" do
+      rest =
+        Rest.new("4")
+        |> Satie.attach(Fermata.new(:short), direction: :down)
 
-      assert Fermata.new(:long) |> Satie.to_lilypond() == "\\longfermata"
+      assert Satie.to_lilypond(rest) ==
+               """
+               r4
+                 _ \\shortfermata
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/key_signature_test.exs
+++ b/test/satie/key_signature_test.exs
@@ -1,23 +1,38 @@
 defmodule Satie.KeySignatureTest do
   use ExUnit.Case, async: true
 
-  alias Satie.KeySignature
+  import DescribeFunction
+
+  alias Satie.{KeySignature, Note, PitchClass}
 
   doctest KeySignature
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a key signature" do
-      assert KeySignature.new("c") |> to_string() == "c major"
-
-      assert KeySignature.new("ef", :minor) |> to_string() == "ef minor"
+  describe_function &KeySignature.new/2 do
+    test "returns the correct components" do
+      assert KeySignature.new("d") == %KeySignature{
+               pitch_class: PitchClass.new("d"),
+               mode: :major,
+               components: [
+                 before: [
+                   "\\key d \\major"
+                 ]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a key signature" do
-      assert KeySignature.new("c") |> Satie.to_lilypond() == "\\key c \\major"
+  describe "attaching a key signature to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("ef'8")
+        |> Satie.attach(KeySignature.new("ef", :lydian))
 
-      assert KeySignature.new("ef", :minor) |> Satie.to_lilypond() == "\\key ef \\minor"
+      assert Satie.to_lilypond(note) ==
+               """
+               \\key ef \\lydian
+               ef'8
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/laissez_vibrer_test.exs
+++ b/test/satie/laissez_vibrer_test.exs
@@ -1,19 +1,37 @@
 defmodule Satie.LaissezVibrerTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.LaissezVibrer
+  alias Satie.{Chord, LaissezVibrer}
 
   doctest LaissezVibrer
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of an laissez vibrer tie" do
-      assert LaissezVibrer.new() |> to_string() == "\\laissezVibrer"
+  describe_function &LaissezVibrer.new/0 do
+    test "returns the correct components" do
+      assert LaissezVibrer.new() == %LaissezVibrer{
+               components: [
+                 after: ["\\laissezVibrer"]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a laissez vibrer tie" do
-      assert LaissezVibrer.new() |> Satie.to_lilypond() == "\\laissezVibrer"
+  describe "attaching a laissez vibrer to a chord" do
+    test "returns the correct lilypond" do
+      chord =
+        Chord.new("< c e g >8")
+        |> Satie.attach(LaissezVibrer.new(), direction: :up)
+
+      assert Satie.to_lilypond(chord) ==
+               """
+               <
+                 c
+                 e
+                 g
+               >8
+                 ^ \\laissezVibrer
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/measure_test.exs
+++ b/test/satie/measure_test.exs
@@ -13,7 +13,10 @@ defmodule Satie.MeasureTest do
 
       assert measure.time_signature == %TimeSignature{
                numerator: 3,
-               denominator: 4
+               denominator: 4,
+               components: [
+                 before: ["\\time 3/4"]
+               ]
              }
 
       assert length(measure.contents) == 1
@@ -26,7 +29,13 @@ defmodule Satie.MeasureTest do
 
     test "can be initialized with a time signature tuple" do
       assert Measure.new({4, 4}) == %Measure{
-               time_signature: %TimeSignature{numerator: 4, denominator: 4},
+               time_signature: %TimeSignature{
+                 numerator: 4,
+                 denominator: 4,
+                 components: [
+                   before: ["\\time 4/4"]
+                 ]
+               },
                contents: []
              }
     end

--- a/test/satie/multi_measure_rest_test.exs
+++ b/test/satie/multi_measure_rest_test.exs
@@ -8,7 +8,10 @@ defmodule Satie.MultiMeasureRestTest do
       assert MultiMeasureRest.new("R1*1/8*17") == %MultiMeasureRest{
                time_signature: %TimeSignature{
                  numerator: 1,
-                 denominator: 8
+                 denominator: 8,
+                 components: [
+                   before: ["\\time 1/8"]
+                 ]
                },
                measures: 17
              }
@@ -18,7 +21,10 @@ defmodule Satie.MultiMeasureRestTest do
       assert MultiMeasureRest.new("3/4*10") == %MultiMeasureRest{
                time_signature: %TimeSignature{
                  numerator: 3,
-                 denominator: 4
+                 denominator: 4,
+                 components: [
+                   before: ["\\time 3/4"]
+                 ]
                },
                measures: 10
              }
@@ -34,7 +40,10 @@ defmodule Satie.MultiMeasureRestTest do
       assert MultiMeasureRest.new(TimeSignature.new(3, 4), 4) == %MultiMeasureRest{
                time_signature: %TimeSignature{
                  numerator: 3,
-                 denominator: 4
+                 denominator: 4,
+                 components: [
+                   before: ["\\time 3/4"]
+                 ]
                },
                measures: 4
              }

--- a/test/satie/ottava_test.exs
+++ b/test/satie/ottava_test.exs
@@ -2,11 +2,16 @@ defmodule Satie.OttavaTest do
   use ExUnit.Case, async: true
   import DescribeFunction
 
-  alias Satie.Ottava
+  alias Satie.{Note, Ottava}
 
   describe_function &Ottava.new/1 do
     test "returns an ottava setting with an integer argument" do
-      assert Ottava.new(1) == %Ottava{degree: 1}
+      assert Ottava.new(1) == %Ottava{
+               degree: 1,
+               components: [
+                 before: ["\\ottava #1"]
+               ]
+             }
     end
 
     test "returns an error tuple with any non-integer argument" do
@@ -16,21 +21,26 @@ defmodule Satie.OttavaTest do
     end
   end
 
-  describe_function &String.Chars.to_string/1 do
-    test "returns a string representation of the ottava" do
-      assert Ottava.new(-1) |> to_string() == "\\ottava #-1"
-    end
-  end
-
   describe_function &Inspect.inspect/2 do
     test "returns the ottava setting formatted for IEx" do
       assert Ottava.new(2) |> inspect() == "#Satie.Ottava<2>"
     end
   end
 
-  describe_function &Satie.ToLilypond.to_lilypond/2 do
-    test "returns the correct lilypond represenation of the ottava setting" do
-      assert Ottava.new(0) |> Satie.to_lilypond() == "\\ottava #0"
+  describe "attaching ottavas to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(Ottava.new(0), position: :after)
+        |> Satie.attach(Ottava.new(1))
+
+      assert Satie.to_lilypond(note) ==
+               """
+               \\ottava #1
+               c'4
+                 \\ottava #0
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/repeat_tie_test.exs
+++ b/test/satie/repeat_tie_test.exs
@@ -1,19 +1,31 @@
 defmodule Satie.RepeatTieTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.RepeatTie
+  alias Satie.{Note, RepeatTie}
 
   doctest RepeatTie
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a repeat tie" do
-      assert RepeatTie.new() |> to_string() == "\\repeatTie"
+  describe_function &RepeatTie.new/0 do
+    test "returns the correct component" do
+      assert RepeatTie.new() == %RepeatTie{
+               components: [
+                 after: ["\\repeatTie"]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a tie" do
-      assert RepeatTie.new() |> Satie.to_lilypond() == "\\repeatTie"
-    end
+  describe "attaching a repeat tie to a note" do
+    note =
+      Note.new("c'4")
+      |> Satie.attach(RepeatTie.new())
+
+    assert Satie.to_lilypond(note) ==
+             """
+             c'4
+               - \\repeatTie
+             """
+             |> String.trim()
   end
 end

--- a/test/satie/start_beam_test.exs
+++ b/test/satie/start_beam_test.exs
@@ -1,19 +1,35 @@
 defmodule Satie.StartBeamTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.StartBeam
+  alias Satie.{Note, StartBeam}
 
   doctest StartBeam
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a beam start" do
-      assert StartBeam.new() |> to_string() == "["
+  describe_function &StartBeam.new/0 do
+    test "returns the correct components" do
+      assert StartBeam.new() == %StartBeam{
+               components: [
+                 after: [
+                   "["
+                 ]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a beam start" do
-      assert StartBeam.new() |> Satie.to_lilypond() == "["
+  describe "attaching a start beam to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(StartBeam.new(), direction: :down)
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 _ [
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/start_hairpin_test.exs
+++ b/test/satie/start_hairpin_test.exs
@@ -2,22 +2,38 @@ defmodule Satie.StartHairpinTest do
   use ExUnit.Case, async: true
   import DescribeFunction
 
-  alias Satie.StartHairpin
+  alias Satie.{Note, StartHairpin}
 
   doctest StartHairpin
 
-  describe_function &StartHairpin.new/1 do
+  describe_function &StartHairpin.new/2 do
     test "can take a lilypond string or a descriptive atom" do
       for token <- [:<, :crescendo, :cresc] do
-        assert StartHairpin.new(token) == %StartHairpin{direction: :crescendo}
+        assert StartHairpin.new(token) == %StartHairpin{
+                 direction: :crescendo,
+                 output: :symbol,
+                 components: [after: ["\\<"]]
+               }
 
-        assert StartHairpin.new(to_string(token)) == %StartHairpin{direction: :crescendo}
+        assert StartHairpin.new(to_string(token), output: :text) == %StartHairpin{
+                 direction: :crescendo,
+                 output: :text,
+                 components: [after: ["\\cresc"]]
+               }
       end
 
       for token <- [:>, :decrescendo, :decresc] do
-        assert StartHairpin.new(token) == %StartHairpin{direction: :decrescendo}
+        assert StartHairpin.new(token, output: :text) == %StartHairpin{
+                 direction: :decrescendo,
+                 output: :text,
+                 components: [after: ["\\decresc"]]
+               }
 
-        assert StartHairpin.new(to_string(token)) == %StartHairpin{direction: :decrescendo}
+        assert StartHairpin.new(to_string(token), output: :symbol) == %StartHairpin{
+                 direction: :decrescendo,
+                 output: :symbol,
+                 components: [after: ["\\>"]]
+               }
       end
     end
 
@@ -30,21 +46,37 @@ defmodule Satie.StartHairpinTest do
     end
   end
 
-  describe_function &String.Chars.to_string/1 do
-    test "returns a reasonable string representation of the hairpin start" do
-      assert StartHairpin.new(">") |> to_string() == "\\>"
-    end
-  end
-
   describe_function &Inspect.inspect/2 do
     test "returns the hairpin start formatted for IEx" do
       assert StartHairpin.new(">") |> inspect() == "#Satie.StartHairpin<decrescendo>"
     end
   end
 
-  describe_function &Satie.ToLilypond.to_lilypond/2 do
-    test "returns a valid lilypond formatting for the hairpin start" do
-      assert StartHairpin.new(">") |> Satie.to_lilypond() == "\\>"
+  describe "attaching a hairpin to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(StartHairpin.new(:crescendo), direction: :up)
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 ^ \\<
+               """
+               |> String.trim()
+    end
+
+    test "returns the correct lilypond with text output" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(StartHairpin.new(:>, output: :text))
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 - \\decresc
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/start_pedal_test.exs
+++ b/test/satie/start_pedal_test.exs
@@ -2,31 +2,50 @@ defmodule Satie.StartPedalTest do
   use ExUnit.Case, async: true
   import DescribeFunction
 
-  alias Satie.StartPedal
+  alias Satie.{Note, StartPedal}
 
   doctest StartPedal
 
   describe_function &StartPedal.new/1 do
     test "can take atom or string values for the proper pedal names" do
-      assert StartPedal.new() == %StartPedal{pedal: :sustain}
-      assert StartPedal.new(:sustain) == %StartPedal{pedal: :sustain}
-      assert StartPedal.new(:sostenuto) == %StartPedal{pedal: :sostenuto}
-      assert StartPedal.new(:corda) == %StartPedal{pedal: :corda}
-      assert StartPedal.new("sustain") == %StartPedal{pedal: :sustain}
-      assert StartPedal.new("sostenuto") == %StartPedal{pedal: :sostenuto}
-      assert StartPedal.new("corda") == %StartPedal{pedal: :corda}
+      assert StartPedal.new() == %StartPedal{
+               pedal: :sustain,
+               components: [after: ["\\sustainOn"]]
+             }
+
+      assert StartPedal.new(:sustain) == %StartPedal{
+               pedal: :sustain,
+               components: [after: ["\\sustainOn"]]
+             }
+
+      assert StartPedal.new(:sostenuto) == %StartPedal{
+               pedal: :sostenuto,
+               components: [after: ["\\sostenutoOn"]]
+             }
+
+      assert StartPedal.new(:corda) == %StartPedal{
+               pedal: :corda,
+               components: [after: ["\\unaCorda"]]
+             }
+
+      assert StartPedal.new("sustain") == %StartPedal{
+               pedal: :sustain,
+               components: [after: ["\\sustainOn"]]
+             }
+
+      assert StartPedal.new("sostenuto") == %StartPedal{
+               pedal: :sostenuto,
+               components: [after: ["\\sostenutoOn"]]
+             }
+
+      assert StartPedal.new("corda") == %StartPedal{
+               pedal: :corda,
+               components: [after: ["\\unaCorda"]]
+             }
     end
 
     test "returns an error tuple for invalid input" do
       assert StartPedal.new("whatever") == {:error, :start_pedal_new, "whatever"}
-    end
-  end
-
-  describe_function &String.Chars.to_string/1 do
-    test "returns a string representation of a pedal start event" do
-      assert StartPedal.new() |> to_string() == "\\sustainOn"
-      assert StartPedal.new(:sostenuto) |> to_string() == "\\sostenutoOn"
-      assert StartPedal.new("corda") |> to_string() == "\\unaCorda"
     end
   end
 
@@ -38,11 +57,18 @@ defmodule Satie.StartPedalTest do
     end
   end
 
-  describe_function &Satie.ToLilypond.to_lilypond/2 do
-    test "returns a correct lilypond representation of a pedal start event" do
-      assert StartPedal.new() |> Satie.to_lilypond() == "\\sustainOn"
-      assert StartPedal.new(:sostenuto) |> Satie.to_lilypond() == "\\sostenutoOn"
-      assert StartPedal.new("corda") |> Satie.to_lilypond() == "\\unaCorda"
+  describe "attaching pedal start events to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(StartPedal.new("corda"))
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 \\unaCorda
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/start_phrasing_slur_test.exs
+++ b/test/satie/start_phrasing_slur_test.exs
@@ -1,19 +1,31 @@
 defmodule Satie.StartPhrasingSlurTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.StartPhrasingSlur
+  alias Satie.{Note, StartPhrasingSlur}
 
   doctest StartPhrasingSlur
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a phrasing slur start" do
-      assert StartPhrasingSlur.new() |> to_string() == "\\("
+  describe_function &StartPhrasingSlur.new/0 do
+    test "returns the correct component" do
+      assert StartPhrasingSlur.new() == %StartPhrasingSlur{
+               components: [after: ["\\("]]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a phrasing slur start" do
-      assert StartPhrasingSlur.new() |> Satie.to_lilypond() == "\\("
+  describe "attaching a phrasing slur to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(StartPhrasingSlur.new(), direction: :up)
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 ^ \\(
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/start_slur_test.exs
+++ b/test/satie/start_slur_test.exs
@@ -1,19 +1,33 @@
 defmodule Satie.StartSlurTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.StartSlur
+  alias Satie.{Note, StartSlur}
 
   doctest StartSlur
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a slur start" do
-      assert StartSlur.new() |> to_string() == "("
+  describe_function &StartSlur.new/0 do
+    test "returns the correct component" do
+      assert StartSlur.new() == %StartSlur{
+               components: [
+                 after: ["("]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a slur start" do
-      assert StartSlur.new() |> Satie.to_lilypond() == "("
+  describe "attaching a slur to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(StartSlur.new())
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 - (
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/stop_beam_test.exs
+++ b/test/satie/stop_beam_test.exs
@@ -1,19 +1,31 @@
 defmodule Satie.StopBeamTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.StopBeam
+  alias Satie.{Note, StopBeam}
 
   doctest StopBeam
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a slur stop" do
-      assert StopBeam.new() |> to_string() == "]"
+  describe_function &StopBeam.new/0 do
+    test "returns the correct component" do
+      assert StopBeam.new() == %StopBeam{
+               components: [after: ["]"]]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a slur start" do
-      assert StopBeam.new() |> Satie.to_lilypond() == "]"
+  describe "attaching a stop beam event to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'8")
+        |> Satie.attach(StopBeam.new())
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'8
+                 ]
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/stop_hairpin_test.exs
+++ b/test/satie/stop_hairpin_test.exs
@@ -2,19 +2,32 @@ defmodule Satie.StopHairpinTest do
   use ExUnit.Case, async: true
   import DescribeFunction
 
-  alias Satie.StopHairpin
+  alias Satie.{Note, StopHairpin}
 
   doctest StopHairpin
 
-  describe_function &String.Chars.to_string/1 do
-    test "returns a string represenation of a hairpin stop" do
-      assert StopHairpin.new() |> to_string() == "\\!"
+  describe_function &StopHairpin.new/0 do
+    test "returns the correct component" do
+      assert StopHairpin.new() == %StopHairpin{
+               components: [
+                 after: ["\\!"]
+               ]
+             }
     end
   end
 
-  describe_function &Satie.ToLilypond.to_lilypond/2 do
-    test "returns the correct lilypond represenation of a hairpin stop" do
-      assert StopHairpin.new() |> Satie.to_lilypond() == "\\!"
+  describe "attaching a stop hairpin event to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(StopHairpin.new())
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 \\!
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/stop_phrasing_slur_test.exs
+++ b/test/satie/stop_phrasing_slur_test.exs
@@ -1,19 +1,35 @@
 defmodule Satie.StopPhrasingSlurTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.StopPhrasingSlur
+  alias Satie.{Note, StopPhrasingSlur}
 
   doctest StopPhrasingSlur
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a phrasing slur stop" do
-      assert StopPhrasingSlur.new() |> to_string() == "\\)"
+  describe_function &StopPhrasingSlur.new/0 do
+    test "returns the correct components" do
+      assert StopPhrasingSlur.new() == %StopPhrasingSlur{
+               components: [
+                 after: [
+                   "\\)"
+                 ]
+               ]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a phrasing slur start" do
-      assert StopPhrasingSlur.new() |> Satie.to_lilypond() == "\\)"
+  describe "attaching a stop phrasing slur event to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(StopPhrasingSlur.new())
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 \\)
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/stop_slur_test.exs
+++ b/test/satie/stop_slur_test.exs
@@ -1,19 +1,31 @@
 defmodule Satie.StopSlurTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.StopSlur
+  alias Satie.{Note, StopSlur}
 
   doctest StopSlur
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a slur stop" do
-      assert StopSlur.new() |> to_string() == ")"
+  describe_function &StopSlur.new/0 do
+    test "returns the correct components" do
+      assert StopSlur.new() == %StopSlur{
+               components: [after: [")"]]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a slur start" do
-      assert StopSlur.new() |> Satie.to_lilypond() == ")"
+  describe "attaching a stop slur event to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(StopSlur.new())
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 )
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/tie_test.exs
+++ b/test/satie/tie_test.exs
@@ -1,19 +1,31 @@
 defmodule Satie.TieTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.Tie
+  alias Satie.{Note, Tie}
 
   doctest Tie
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a tie" do
-      assert Tie.new() |> to_string() == "~"
+  describe_function &Tie.new/0 do
+    test "returns the correct components" do
+      assert Tie.new() == %Tie{
+               components: [after: ["~"]]
+             }
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a tie" do
-      assert Tie.new() |> Satie.to_lilypond() == "~"
+  describe "attaching a tie to a note" do
+    test "returns the correct lilypond" do
+      note =
+        Note.new("c'4")
+        |> Satie.attach(Tie.new(), direction: :up)
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c'4
+                 ^ ~
+               """
+               |> String.trim()
     end
   end
 end

--- a/test/satie/time_signature_test.exs
+++ b/test/satie/time_signature_test.exs
@@ -1,20 +1,27 @@
 defmodule Satie.TimeSignatureTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.TimeSignature
+  alias Satie.{Rest, TimeSignature}
 
-  describe inspect(&TimeSignature.new/1) do
+  describe_function &TimeSignature.new/1 do
     test "parses a valid string into a time signature" do
       assert TimeSignature.new("\\time 3/16") == %TimeSignature{
                numerator: 3,
-               denominator: 16
+               denominator: 16,
+               components: [
+                 before: ["\\time 3/16"]
+               ]
              }
     end
 
     test "doesn't require the `\\time` at the beginning" do
       assert TimeSignature.new("7/16") == %TimeSignature{
                numerator: 7,
-               denominator: 16
+               denominator: 16,
+               components: [
+                 before: ["\\time 7/16"]
+               ]
              }
     end
 
@@ -25,18 +32,24 @@ defmodule Satie.TimeSignatureTest do
     end
   end
 
-  describe inspect(&TimeSignature.new/2) do
+  describe_function &TimeSignature.new/2 do
     test "creates a new time signature from two integers" do
       assert TimeSignature.new(3, 4) == %TimeSignature{
                numerator: 3,
-               denominator: 4
+               denominator: 4,
+               components: [
+                 before: ["\\time 3/4"]
+               ]
              }
     end
 
     test "doesn't reduce a fraction" do
       assert TimeSignature.new(4, 8) == %TimeSignature{
                numerator: 4,
-               denominator: 8
+               denominator: 8,
+               components: [
+                 before: ["\\time 4/8"]
+               ]
              }
     end
 
@@ -47,21 +60,24 @@ defmodule Satie.TimeSignatureTest do
     end
   end
 
-  describe inspect(&String.Chars.to_string/1) do
-    test "returns a string representation of a time signature" do
-      assert TimeSignature.new(3, 8) |> to_string == "\\time 3/8"
-    end
-  end
-
-  describe inspect(&Inspect.inspect/2) do
+  describe_function &Inspect.inspect/2 do
     test "returns a time signature formatted for IEx" do
       assert TimeSignature.new("\\time 4/8") |> inspect == "#Satie.TimeSignature<4/8>"
     end
   end
 
-  describe inspect(&Satie.ToLilypond.to_lilypond/1) do
-    test "returns the correct lilypond representation of a time signature" do
-      assert TimeSignature.new(11, 8) |> Satie.to_lilypond() == "\\time 11/8"
+  describe "attaching a timesignature to a rest" do
+    test "returns the correct lilypond" do
+      rest =
+        Rest.new("4")
+        |> Satie.attach(TimeSignature.new("3/4"))
+
+      assert Satie.to_lilypond(rest) ==
+               """
+               \\time 3/4
+               r4
+               """
+               |> String.trim()
     end
   end
 end


### PR DESCRIPTION
Reimplement attachments
---

Rather than implementing Satie.ToLilypond for attachments, each
`Attachable` struct stores a list of `components` that are attached
directly to the note/rest/etc. These components are stored based on
their default location relative to their target, but this can be
overridden by options passed to `Satie.Attach`.
