### PR TITLE
Add `Fraction`

### DIFF
--- a/lib/satie/duration.ex
+++ b/lib/satie/duration.ex
@@ -6,8 +6,20 @@ defmodule Satie.Duration do
 
   import Satie.Guards
 
+  alias Satie.{Fraction, Multiplier, Offset}
+
   use Satie.Fractional
-  alias Satie.Multiplier
+
+  use Satie.Fractional.Math,
+    add: [{Fraction, Fraction}],
+    subtract: [{Fraction, Fraction}],
+    multiply: [{Fraction, Fraction}],
+    divide: [
+      {__MODULE__, Multiplier},
+      {Fraction, Fraction},
+      {Multiplier, Multiplier},
+      {Offset, Multiplier}
+    ]
 
   @doc """
 
@@ -30,40 +42,6 @@ defmodule Satie.Duration do
   def printable?(%__MODULE__{} = duration) do
     [&proper_length?/1, &printable_subdivision?/1, &not_tied?/1]
     |> Enum.all?(& &1.(duration))
-  end
-
-  def add(%__MODULE__{} = duration, rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-    new(n1 * d2 + n2 * d1, d1 * d2)
-  end
-
-  def subtract(%__MODULE__{} = duration, rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-    new(n1 * d2 - n2 * d1, d1 * d2)
-  end
-
-  def multiply(%__MODULE__{} = duration, rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-    new(n1 * n2, d1 * d2)
-  end
-
-  def multiply(%__MODULE__{} = duration, rhs) when is_integer(rhs) do
-    {n, d} = Fractional.to_tuple(duration)
-    new(n * rhs, d)
-  end
-
-  def divide(%__MODULE__{} = duration, rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-    Multiplier.new(n1 * d2, n2 * d1)
-  end
-
-  def divide(%__MODULE__{} = duration, rhs) when is_integer(rhs) and rhs != 0 do
-    {n, d} = Fractional.to_tuple(duration)
-    new(n, d * rhs)
   end
 
   defp proper_length?(%__MODULE__{numerator: n, denominator: d}) do

--- a/lib/satie/fraction.ex
+++ b/lib/satie/fraction.ex
@@ -1,0 +1,28 @@
+defmodule Satie.Fraction do
+  @moduledoc """
+    Modules a non-reduced fraction.
+  """
+
+  defstruct [:numerator, :denominator]
+
+  use Satie.Fractional, reduce: false
+  use Satie.Fractional.Math
+
+  def new(fraction), do: Satie.ToFraction.from(fraction)
+
+  def new(numerator, denominator) do
+    new({numerator, denominator})
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(%@for{numerator: n, denominator: d}, _) do
+      concat([
+        "#Satie.Fraction<",
+        "#{n}/#{d}",
+        ">"
+      ])
+    end
+  end
+end

--- a/lib/satie/fractional/math.ex
+++ b/lib/satie/fractional/math.ex
@@ -1,0 +1,61 @@
+defmodule Satie.Fractional.Math do
+  @moduledoc """
+    Models common arithmetic functions between fractional types
+  """
+
+  defmacro __using__(conversions) do
+    quote do
+      alias Satie.Fractional
+      import Satie.Guards
+
+      def add(%__MODULE__{} = fraction, %rhs_struct{} = rhs) when is_fractional(rhs) do
+        {n1, d1} = Fractional.to_tuple(fraction)
+        {n2, d2} = Fractional.to_tuple(rhs)
+
+        return_struct = find_return_struct(:add, rhs_struct)
+        return_struct.new(n1 * d2 + n2 * d1, d1 * d2)
+      end
+
+      def subtract(%__MODULE__{} = fraction, %rhs_struct{} = rhs) when is_fractional(rhs) do
+        {n1, d1} = Fractional.to_tuple(fraction)
+        {n2, d2} = Fractional.to_tuple(rhs)
+
+        return_struct = find_return_struct(:subtract, rhs_struct)
+        return_struct.new(n1 * d2 - n2 * d1, d1 * d2)
+      end
+
+      def multiply(%__MODULE__{} = fraction, %rhs_struct{} = rhs) when is_fractional(rhs) do
+        {n1, d1} = Fractional.to_tuple(fraction)
+        {n2, d2} = Fractional.to_tuple(rhs)
+
+        return_struct = find_return_struct(:multiply, rhs_struct)
+        return_struct.new(n1 * n2, d1 * d2)
+      end
+
+      def multiply(%__MODULE__{} = fraction, rhs) when is_integer(rhs) do
+        {n, d} = Fractional.to_tuple(fraction)
+        new(n * rhs, d)
+      end
+
+      def divide(%__MODULE__{} = fraction, %rhs_struct{} = rhs) when is_fractional(rhs) do
+        {n1, d1} = Fractional.to_tuple(fraction)
+        {n2, d2} = Fractional.to_tuple(rhs)
+
+        return_struct = find_return_struct(:divide, rhs_struct)
+        return_struct.new(n1 * d2, n2 * d1)
+      end
+
+      def divide(%__MODULE__{} = fraction, rhs) when is_integer(rhs) and rhs != 0 do
+        {n, d} = Fractional.to_tuple(fraction)
+        new(n, d * rhs)
+      end
+
+      defp find_return_struct(key, rhs_struct) do
+        unquote(conversions)
+        |> Keyword.get(key, [])
+        |> Enum.find({__MODULE__, __MODULE__}, fn {src, _} -> src == rhs_struct end)
+        |> elem(1)
+      end
+    end
+  end
+end

--- a/lib/satie/lilypond/parser.ex
+++ b/lib/satie/lilypond/parser.ex
@@ -47,6 +47,19 @@ defmodule Satie.Lilypond.Parser do
     |> map(fn [base, dots] -> [to_string(base), to_string(dots)] end)
   end
 
+  def fraction do
+    sequence([
+      some(digit()),
+      char(?/),
+      some(digit())
+    ])
+    |> map(fn [n, _, d] ->
+      with {n, ""} <- Integer.parse(to_string(n)),
+           {d, ""} <- Integer.parse(to_string(d)),
+           do: [n, d]
+    end)
+  end
+
   def note do
     sequence([
       notehead(),

--- a/lib/satie/measure.ex
+++ b/lib/satie/measure.ex
@@ -35,8 +35,8 @@ defmodule Satie.Measure do
   end
 
   defimpl String.Chars do
-    def to_string(%@for{time_signature: time_signature, contents: contents}) do
-      %TimeSignature{numerator: n, denominator: d} = time_signature
+    def to_string(%@for{time_signature: %{fraction: fraction}, contents: contents}) do
+      {n, d} = Satie.Fraction.to_tuple(fraction)
 
       [
         "{",
@@ -64,8 +64,8 @@ defmodule Satie.Measure do
   defimpl Satie.ToLilypond do
     import Satie.Lilypond.OutputHelpers
 
-    def to_lilypond(%@for{time_signature: time_signature, contents: contents}, _opts) do
-      %TimeSignature{numerator: n, denominator: d} = time_signature
+    def to_lilypond(%@for{time_signature: %{fraction: fraction}, contents: contents}, _opts) do
+      {n, d} = Satie.Fraction.to_tuple(fraction)
 
       [
         "{",

--- a/lib/satie/multiplier.ex
+++ b/lib/satie/multiplier.ex
@@ -4,7 +4,7 @@ defmodule Satie.Multiplier do
   """
   defstruct [:numerator, :denominator]
 
-  alias Satie.Duration
+  alias Satie.{Duration, Fraction}
   use Satie.Fractional
   import Satie.Guards
 
@@ -14,43 +14,24 @@ defmodule Satie.Multiplier do
     new({numerator, denominator})
   end
 
-  def add(%__MODULE__{} = duration, rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-    new(n1 * d2 + n2 * d1, d1 * d2)
-  end
+  use Satie.Fractional.Math,
+    add: [{Fraction, Fraction}],
+    subtract: [{Fraction, Fraction}],
+    multiply: [
+      {Duration, Duration},
+      {Fraction, Fraction}
+    ],
+    divide: [{Fraction, Fraction}]
 
-  def subtract(%__MODULE__{} = duration, rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
+  defimpl Inspect do
+    import Inspect.Algebra
 
-    new(n1 * d2 - n2 * d1, d1 * d2)
-  end
-
-  def multiply(%__MODULE__{} = duration, %rhs_struct{} = rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-
-    case rhs_struct do
-      Duration -> Duration.new(n1 * n2, d1 * d2)
-      _ -> new(n1 * n2, d1 * d2)
+    def inspect(%@for{numerator: n, denominator: d}, _) do
+      concat([
+        "#Satie.Multiplier<",
+        "#{n}/#{d}",
+        ">"
+      ])
     end
-  end
-
-  def multiply(%__MODULE__{} = duration, rhs) when is_integer(rhs) do
-    {n, d} = Fractional.to_tuple(duration)
-    new(n * rhs, d)
-  end
-
-  def divide(%__MODULE__{} = duration, rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-
-    new(n1 * d2, n2 * d1)
-  end
-
-  def divide(%__MODULE__{} = duration, rhs) when is_integer(rhs) and rhs != 0 do
-    {n, d} = Fractional.to_tuple(duration)
-    new(n, d * rhs)
   end
 end

--- a/lib/satie/offset.ex
+++ b/lib/satie/offset.ex
@@ -5,7 +5,7 @@ defmodule Satie.Offset do
 
   # alias Satie.Fractional
   use Satie.Fractional
-  alias Satie.{Duration, Multiplier}
+  alias Satie.{Duration, Fraction, Multiplier}
   import Satie.Guards
 
   defstruct [:numerator, :denominator]
@@ -13,25 +13,24 @@ defmodule Satie.Offset do
   @doc """
 
       iex> Offset.new(0)
-      #Satie.Offset<{0, 1}>
+      #Satie.Offset<0/1>
 
       iex> Offset.new(3, 16)
-      #Satie.Offset<{3, 16}>
+      #Satie.Offset<3/16>
 
       iex> Offset.new({5, 18})
-      #Satie.Offset<{5, 18}>
+      #Satie.Offset<5/18>
 
     Reduces fraction
 
       iex> Offset.new(4, 16)
-      #Satie.Offset<{1, 4}>
-
+      #Satie.Offset<1/4>
 
     Can initialize from another Offset
 
       iex> offset = Offset.new(1, 3)
       iex> Offset.new(offset)
-      #Satie.Offset<{1, 3}>
+      #Satie.Offset<1/3>
 
   """
   def new(offset), do: Satie.ToOffset.from(offset)
@@ -49,47 +48,17 @@ defmodule Satie.Offset do
   """
   def to_float(%__MODULE__{numerator: n, denominator: d}), do: n / d
 
-  def add(%__MODULE__{} = duration, rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-    new(n1 * d2 + n2 * d1, d1 * d2)
-  end
-
-  def subtract(%__MODULE__{} = duration, %rhs_struct{} = rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-
-    case rhs_struct do
-      __MODULE__ -> Duration.new(n1 * d2 - n2 * d1, d1 * d2)
-      _ -> new(n1 * d2 - n2 * d1, d1 * d2)
-    end
-  end
-
-  def multiply(%__MODULE__{} = duration, rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-    new(n1 * n2, d1 * d2)
-  end
-
-  def multiply(%__MODULE__{} = duration, rhs) when is_integer(rhs) do
-    {n, d} = Fractional.to_tuple(duration)
-    new(n * rhs, d)
-  end
-
-  def divide(%__MODULE__{} = duration, %rhs_struct{} = rhs) when is_fractional(rhs) do
-    {n1, d1} = Fractional.to_tuple(duration)
-    {n2, d2} = Fractional.to_tuple(rhs)
-
-    case rhs_struct do
-      __MODULE__ -> Multiplier.new(n1 * d2, n2 * d1)
-      _ -> new(n1 * d2, n2 * d1)
-    end
-  end
-
-  def divide(%__MODULE__{} = duration, rhs) when is_integer(rhs) and rhs != 0 do
-    {n, d} = Fractional.to_tuple(duration)
-    new(n, d * rhs)
-  end
+  use Satie.Fractional.Math,
+    add: [{Fraction, Fraction}],
+    subtract: [
+      {__MODULE__, Duration},
+      {Fraction, Duration}
+    ],
+    multiply: [{Fraction, Fraction}],
+    divide: [
+      {__MODULE__, Multiplier},
+      {Fraction, Fraction}
+    ]
 
   def eq(%__MODULE__{} = offset1, %__MODULE__{} = offset2) do
     to_float(offset1) == to_float(offset2)
@@ -119,12 +88,11 @@ defmodule Satie.Offset do
 
   defimpl Inspect do
     import Inspect.Algebra
-    alias Satie.Fractional
 
-    def inspect(%@for{} = offset, _opts) do
+    def inspect(%@for{numerator: n, denominator: d}, _opts) do
       concat([
         "#Satie.Offset<",
-        inspect(Fractional.to_tuple(offset)),
+        "#{n}/#{d}",
         ">"
       ])
     end

--- a/lib/satie/time_signature.ex
+++ b/lib/satie/time_signature.ex
@@ -3,9 +3,10 @@ defmodule Satie.TimeSignature do
   Models a time signature
   """
 
-  # TODO: have this use a Fraction
+  alias Satie.Fraction
+
   use Satie.Attachable,
-    fields: [:numerator, :denominator],
+    fields: [:fraction],
     location: :before,
     priority: 3,
     has_direction: false
@@ -26,8 +27,7 @@ defmodule Satie.TimeSignature do
 
   def new(numerator, denominator) when is_integer(numerator) and is_integer(denominator) do
     %__MODULE__{
-      numerator: numerator,
-      denominator: denominator,
+      fraction: Fraction.new(numerator, denominator),
       components: [
         before: [
           "\\time #{numerator}/#{denominator}"
@@ -41,7 +41,9 @@ defmodule Satie.TimeSignature do
   defimpl Inspect do
     import Inspect.Algebra
 
-    def inspect(%@for{numerator: n, denominator: d}, _opts) do
+    def inspect(%@for{fraction: fraction}, _opts) do
+      {n, d} = Fraction.to_tuple(fraction)
+
       concat([
         "#Satie.TimeSignature<",
         "#{n}/#{d}",

--- a/lib/satie/timespan.ex
+++ b/lib/satie/timespan.ex
@@ -42,9 +42,9 @@ defmodule Satie.Timespan do
       iex> timespan = Timespan.new(0, 10)
       iex> [start, stop] = Timespan.offsets(timespan)
       iex> start
-      #Satie.Offset<{0, 1}>
+      #Satie.Offset<0/1>
       iex> stop
-      #Satie.Offset<{10, 1}>
+      #Satie.Offset<10/1>
 
   """
   def offsets(%__MODULE__{start_offset: start_offset, stop_offset: stop_offset}) do
@@ -55,7 +55,7 @@ defmodule Satie.Timespan do
 
       iex> timespan = Timespan.new(0, 10)
       iex> Timespan.start_offset(timespan)
-      #Satie.Offset<{0, 1}>
+      #Satie.Offset<0/1>
 
       iex> timespan = Timespan.new(0, 10)
       iex> Timespan.start_offset(timespan, Offset.new(3))
@@ -73,7 +73,7 @@ defmodule Satie.Timespan do
 
       iex> timespan = Timespan.new(0, 10)
       iex> Timespan.stop_offset(timespan)
-      #Satie.Offset<{10, 1}>
+      #Satie.Offset<10/1>
 
       iex> timespan = Timespan.new(0, 10)
       iex> Timespan.stop_offset(timespan, Offset.new(3))
@@ -198,7 +198,7 @@ defmodule Satie.Timespan do
 
       iex> timespan = Timespan.new(0, 10)
       iex> Timespan.axis(timespan)
-      #Satie.Offset<{5, 1}>
+      #Satie.Offset<5/1>
 
   """
   def axis(%__MODULE__{start_offset: start_offset, stop_offset: stop_offset}) do

--- a/lib/satie/timespan_list.ex
+++ b/lib/satie/timespan_list.ex
@@ -94,9 +94,9 @@ defmodule Satie.TimespanList do
     ...> ])
     iex> [start, stop] = TimespanList.offsets(timespan_list)
     iex> start
-    #Satie.Offset<{-2, 1}>
+    #Satie.Offset<-2/1>
     iex> stop
-    #Satie.Offset<{15, 1}>
+    #Satie.Offset<15/1>
 
   """
   def offsets(%__MODULE__{} = timespan_list) do
@@ -113,7 +113,7 @@ defmodule Satie.TimespanList do
     ...>   Timespan.new(10, 15),
     ...> ])
     iex> TimespanList.start_offset(timespan_list)
-    #Satie.Offset<{-2, 1}>
+    #Satie.Offset<-2/1>
 
   """
   def start_offset(%__MODULE__{} = timespan_list) do
@@ -130,7 +130,7 @@ defmodule Satie.TimespanList do
     ...>   Timespan.new(10, 15),
     ...> ])
     iex> TimespanList.stop_offset(timespan_list)
-    #Satie.Offset<{15, 1}>
+    #Satie.Offset<15/1>
 
   """
   def stop_offset(%__MODULE__{} = timespan_list) do
@@ -147,7 +147,7 @@ defmodule Satie.TimespanList do
     ...>   Timespan.new(10, 16),
     ...> ])
     iex> TimespanList.axis(timespan_list)
-    #Satie.Offset<{7, 1}>
+    #Satie.Offset<7/1>
 
   """
   def axis(%__MODULE__{} = timespan_list) do

--- a/lib/satie/to_duration.ex
+++ b/lib/satie/to_duration.ex
@@ -11,7 +11,7 @@ defimpl Satie.ToDuration, for: Satie.Duration do
   def from(duration), do: duration
 end
 
-for fractional <- [Satie.Offset, Satie.Multiplier] do
+for fractional <- [Satie.Fraction, Satie.Offset, Satie.Multiplier] do
   defimpl Satie.ToDuration, for: fractional do
     def from(%@for{numerator: n, denominator: d}), do: Satie.Duration.__init__({n, d})
   end

--- a/lib/satie/to_fraction.ex
+++ b/lib/satie/to_fraction.ex
@@ -1,0 +1,45 @@
+defprotocol Satie.ToFraction do
+  @fallback_to_any true
+  def from(_)
+end
+
+defimpl Satie.ToFraction, for: Any do
+  def from(x), do: {:error, :fraction_new, x}
+end
+
+defimpl Satie.ToFraction, for: Satie.Fraction do
+  def from(fraction), do: fraction
+end
+
+for fractional <- [Satie.Duration, Satie.Multiplier, Satie.Offset] do
+  defimpl Satie.ToFraction, for: fractional do
+    def from(%@for{numerator: n, denominator: d}), do: Satie.Fraction.__init__({n, d})
+  end
+end
+
+defimpl Satie.ToFraction, for: BitString do
+  def from(fraction) do
+    case Satie.Lilypond.Parser.fraction().(fraction) do
+      {:ok, [n, d], ""} ->
+        @protocol.from({n, d})
+
+      _ ->
+        {:error, :fraction_new, fraction}
+    end
+  end
+end
+
+defimpl Satie.ToFraction, for: Integer do
+  def from(numerator), do: @protocol.from({numerator, 1})
+end
+
+defimpl Satie.ToFraction, for: Tuple do
+  import Satie.Guards
+
+  def from(fraction) when is_integer_duple(fraction) do
+    fraction
+    |> Satie.Fraction.__init__()
+  end
+
+  def from(tuple), do: {:error, :fraction_new, tuple}
+end

--- a/lib/satie/to_multiplier.ex
+++ b/lib/satie/to_multiplier.ex
@@ -11,9 +11,21 @@ defimpl Satie.ToMultiplier, for: Satie.Multiplier do
   def from(multiplier), do: multiplier
 end
 
-for fractional <- [Satie.Duration, Satie.Offset] do
+for fractional <- [Satie.Duration, Satie.Fraction, Satie.Offset] do
   defimpl Satie.ToMultiplier, for: fractional do
     def from(%@for{numerator: n, denominator: d}), do: Satie.Multiplier.__init__({n, d})
+  end
+end
+
+defimpl Satie.ToMultiplier, for: BitString do
+  def from(multiplier) do
+    case Satie.Lilypond.Parser.fraction().(multiplier) do
+      {:ok, [n, d], ""} ->
+        @protocol.from({n, d})
+
+      _ ->
+        {:error, :multiplier_new, multiplier}
+    end
   end
 end
 

--- a/lib/satie/to_offset.ex
+++ b/lib/satie/to_offset.ex
@@ -11,9 +11,21 @@ defimpl Satie.ToOffset, for: Satie.Offset do
   def from(offset), do: offset
 end
 
-for fractional <- [Satie.Duration, Satie.Multiplier] do
+for fractional <- [Satie.Duration, Satie.Fraction, Satie.Multiplier] do
   defimpl Satie.ToOffset, for: fractional do
     def from(%@for{numerator: n, denominator: d}), do: Satie.Offset.__init__({n, d})
+  end
+end
+
+defimpl Satie.ToOffset, for: BitString do
+  def from(offset) do
+    case Satie.Lilypond.Parser.fraction().(offset) do
+      {:ok, [n, d], ""} ->
+        @protocol.from({n, d})
+
+      _ ->
+        {:error, :offset_new, offset}
+    end
   end
 end
 

--- a/test/satie/duration_test.exs
+++ b/test/satie/duration_test.exs
@@ -2,7 +2,7 @@ defmodule Satie.DurationTest do
   use ExUnit.Case, async: true
 
   import Satie.RegressionDataStreamer
-  alias Satie.{Duration, Multiplier, Offset}
+  alias Satie.{Duration, Fraction, Multiplier, Offset}
 
   doctest Duration
 
@@ -40,6 +40,7 @@ defmodule Satie.DurationTest do
 
     test "can be created from another fractional type" do
       assert Duration.new(Duration.new(1, 4)) == %Duration{numerator: 1, denominator: 4}
+      assert Duration.new(Fraction.new(2, 4)) == %Duration{numerator: 1, denominator: 2}
       assert Duration.new(Multiplier.new(2, 4)) == %Duration{numerator: 1, denominator: 2}
       assert Duration.new(Offset.new(1, 3)) == %Duration{numerator: 1, denominator: 3}
     end
@@ -291,6 +292,16 @@ defmodule Satie.DurationTest do
       assert is_struct(Duration.subtract(d1, d2), Duration)
       assert is_struct(Duration.multiply(d1, d2), Duration)
       assert is_struct(Duration.divide(d1, d2), Multiplier)
+    end
+
+    test "against a fraction" do
+      d = Duration.new(3, 8)
+      f = Fraction.new(1, 4)
+
+      assert is_struct(Duration.add(d, f), Fraction)
+      assert is_struct(Duration.subtract(d, f), Fraction)
+      assert is_struct(Duration.multiply(d, f), Fraction)
+      assert is_struct(Duration.divide(d, f), Fraction)
     end
 
     test "against an integer" do

--- a/test/satie/fraction_test.exs
+++ b/test/satie/fraction_test.exs
@@ -1,0 +1,99 @@
+defmodule Satie.FractionTest do
+  use ExUnit.Case, async: true
+  import DescribeFunction
+
+  alias Satie.{Duration, Fraction, Multiplier, Offset}
+
+  describe_function &Fraction.new/1 do
+    test "can be created from another fractional type" do
+      duration = Duration.new(1, 4)
+      fraction = Fraction.new(1, 4)
+      multiplier = Multiplier.new(1, 4)
+      offset = Offset.new(1, 4)
+
+      assert Fraction.new(duration) == fraction
+      assert Fraction.new(fraction) == fraction
+      assert Fraction.new(multiplier) == fraction
+      assert Fraction.new(offset) == fraction
+    end
+
+    test "can be created from a single integer" do
+      assert Fraction.new(3) == %Fraction{numerator: 3, denominator: 1}
+    end
+
+    test "can be created from a string" do
+      assert Fraction.new("4/4") == %Fraction{numerator: 4, denominator: 4}
+    end
+  end
+
+  describe_function &Fraction.new/2 do
+    test "takes integral numerator and denominator" do
+      assert Fraction.new(1, 4) == %Fraction{
+               numerator: 1,
+               denominator: 4
+             }
+    end
+
+    test "does not reduce the fraction" do
+      assert Fraction.new(2, 4) == %Fraction{
+               numerator: 2,
+               denominator: 4
+             }
+    end
+  end
+
+  describe "arithmetic" do
+    test "against a duration" do
+      f = Fraction.new(1, 5)
+      d = Duration.new(1, 8)
+
+      assert is_struct(Fraction.add(f, d), Fraction)
+      assert is_struct(Fraction.subtract(f, d), Fraction)
+      assert is_struct(Fraction.multiply(f, d), Fraction)
+      assert is_struct(Fraction.divide(f, d), Fraction)
+    end
+
+    test "against another fraction" do
+      f1 = Fraction.new(1, 5)
+      f2 = Fraction.new(1, 8)
+
+      assert is_struct(Fraction.add(f1, f2), Fraction)
+      assert is_struct(Fraction.subtract(f1, f2), Fraction)
+      assert is_struct(Fraction.multiply(f1, f2), Fraction)
+      assert is_struct(Fraction.divide(f1, f2), Fraction)
+    end
+
+    test "against an integer" do
+      f = Fraction.new(1, 5)
+
+      assert is_struct(Fraction.multiply(f, 2), Fraction)
+      assert is_struct(Fraction.divide(f, 2), Fraction)
+    end
+
+    test "against a multiplier" do
+      f = Fraction.new(1, 5)
+      m = Multiplier.new(1, 8)
+
+      assert is_struct(Fraction.add(f, m), Fraction)
+      assert is_struct(Fraction.subtract(f, m), Fraction)
+      assert is_struct(Fraction.multiply(f, m), Fraction)
+      assert is_struct(Fraction.divide(f, m), Fraction)
+    end
+
+    test "against an offset" do
+      f = Fraction.new(1, 5)
+      o = Offset.new(1, 8)
+
+      assert is_struct(Fraction.add(f, o), Fraction)
+      assert is_struct(Fraction.subtract(f, o), Fraction)
+      assert is_struct(Fraction.multiply(f, o), Fraction)
+      assert is_struct(Fraction.divide(f, o), Fraction)
+    end
+  end
+
+  describe_function &Inspect.inspect/2 do
+    test "returns a fraction formatted for IEx" do
+      assert Fraction.new(3, 4) |> inspect() == "#Satie.Fraction<3/4>"
+    end
+  end
+end

--- a/test/satie/measure_test.exs
+++ b/test/satie/measure_test.exs
@@ -1,7 +1,7 @@
 defmodule Satie.MeasureTest do
   use ExUnit.Case, async: true
 
-  alias Satie.{Measure, Note, TimeSignature}
+  alias Satie.{Fraction, Measure, Note, TimeSignature}
 
   describe inspect(&Measure.new/2) do
     test "sets a time signature and contents" do
@@ -12,8 +12,7 @@ defmodule Satie.MeasureTest do
         )
 
       assert measure.time_signature == %TimeSignature{
-               numerator: 3,
-               denominator: 4,
+               fraction: Fraction.new(3, 4),
                components: [
                  before: ["\\time 3/4"]
                ]
@@ -30,8 +29,7 @@ defmodule Satie.MeasureTest do
     test "can be initialized with a time signature tuple" do
       assert Measure.new({4, 4}) == %Measure{
                time_signature: %TimeSignature{
-                 numerator: 4,
-                 denominator: 4,
+                 fraction: Fraction.new(4, 4),
                  components: [
                    before: ["\\time 4/4"]
                  ]

--- a/test/satie/multi_measure_rest_test.exs
+++ b/test/satie/multi_measure_rest_test.exs
@@ -1,17 +1,14 @@
 defmodule Satie.MultiMeasureRestTest do
   use ExUnit.Case, async: true
 
-  alias Satie.{MultiMeasureRest, TimeSignature}
+  alias Satie.{MultiMeasureRest, Multiplier, TimeSignature}
 
   describe inspect(&MultiMeasureRest.new/1) do
     test "can parse a multi-measure rest from a string" do
-      assert MultiMeasureRest.new("R1*1/8*17") == %MultiMeasureRest{
-               time_signature: %TimeSignature{
+      assert MultiMeasureRest.new("R1*4/4*17") == %MultiMeasureRest{
+               multiplier: %Multiplier{
                  numerator: 1,
-                 denominator: 8,
-                 components: [
-                   before: ["\\time 1/8"]
-                 ]
+                 denominator: 1
                },
                measures: 17
              }
@@ -19,12 +16,9 @@ defmodule Satie.MultiMeasureRestTest do
 
     test "can parse without the leading `R1`" do
       assert MultiMeasureRest.new("3/4*10") == %MultiMeasureRest{
-               time_signature: %TimeSignature{
+               multiplier: %Multiplier{
                  numerator: 3,
-                 denominator: 4,
-                 components: [
-                   before: ["\\time 3/4"]
-                 ]
+                 denominator: 4
                },
                measures: 10
              }
@@ -36,43 +30,51 @@ defmodule Satie.MultiMeasureRestTest do
   end
 
   describe inspect(&MultiMeasureRest.new/2) do
-    test "creates a multi-measure rest from a time signature and measure count" do
-      assert MultiMeasureRest.new(TimeSignature.new(3, 4), 4) == %MultiMeasureRest{
-               time_signature: %TimeSignature{
+    test "creates a multi-measure rest from a multiplier and measure count" do
+      assert MultiMeasureRest.new(Multiplier.new(3, 4), 4) == %MultiMeasureRest{
+               multiplier: %Multiplier{
                  numerator: 3,
-                 denominator: 4,
-                 components: [
-                   before: ["\\time 3/4"]
-                 ]
+                 denominator: 4
                },
                measures: 4
              }
     end
 
-    test "returns an error if either argument is not the required type" do
-      assert MultiMeasureRest.new({1, 4}, 7) == {:error, :multi_measure_rest_new, {{1, 4}, 7}}
+    test "creates a multi-measure rest from a multiplier-equivalent and measure count" do
+      assert MultiMeasureRest.new({1, 4}, 7) == %MultiMeasureRest{
+               multiplier: %Multiplier{
+                 numerator: 1,
+                 denominator: 4
+               },
+               measures: 7
+             }
+    end
 
-      assert MultiMeasureRest.new(TimeSignature.new("3/4"), 7.5) ==
-               {:error, :multi_measure_rest_new, {TimeSignature.new(3, 4), 7.5}}
+    test "returns an error if either argument is not the required type" do
+      assert MultiMeasureRest.new({3, 4}, 7.5) ==
+               {:error, :multi_measure_rest_new, {{3, 4}, 7.5}}
+
+      assert MultiMeasureRest.new(TimeSignature.new("3/4"), 7) ==
+               {:error, :multi_measure_rest_new, {TimeSignature.new(3, 4), 7}}
     end
   end
 
   describe inspect(&String.Chars.to_string/1) do
     test "returns a string representation of a multi-measure rest" do
-      assert MultiMeasureRest.new(TimeSignature.new("3/4"), 8) |> to_string() == "R1 * 3/4 * 8"
+      assert MultiMeasureRest.new(Multiplier.new("3/4"), 8) |> to_string() == "R1 * 3/4 * 8"
     end
   end
 
   describe inspect(&Inspect.inspect/2) do
     test "returns a multi-measure rest formatted for IEx" do
-      assert MultiMeasureRest.new(TimeSignature.new("7/8"), 3) |> inspect() ==
+      assert MultiMeasureRest.new(Multiplier.new("7/8"), 3) |> inspect() ==
                "#Satie.MultiMeasureRest<7/8 * 3>"
     end
   end
 
   describe inspect(&Satie.ToLilypond.to_lilypond/1) do
     test "returns the correct lilypond representation of a multi-measure rest" do
-      assert MultiMeasureRest.new(TimeSignature.new(11, 8), 17) |> Satie.to_lilypond() ==
+      assert MultiMeasureRest.new(Multiplier.new(11, 8), 17) |> Satie.to_lilypond() ==
                "R1 * 11/8 * 17"
     end
   end

--- a/test/satie/multiplier_test.exs
+++ b/test/satie/multiplier_test.exs
@@ -1,7 +1,26 @@
 defmodule Satie.MultiplierTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.{Duration, Multiplier, Offset}
+  alias Satie.{Duration, Fraction, Multiplier, Offset}
+
+  describe_function &Multiplier.new/1 do
+    test "denominator defaults to 1" do
+      assert Multiplier.new(3) == %Multiplier{numerator: 3, denominator: 1}
+    end
+
+    test "can be created from another fractional type" do
+      assert Multiplier.new(Duration.new(1, 4)) == %Multiplier{numerator: 1, denominator: 4}
+      assert Multiplier.new(Fraction.new(1, 3)) == %Multiplier{numerator: 1, denominator: 3}
+      assert Multiplier.new(Multiplier.new(2, 4)) == %Multiplier{numerator: 1, denominator: 2}
+      assert Multiplier.new(Offset.new(1, 3)) == %Multiplier{numerator: 1, denominator: 3}
+    end
+
+    test "can be created from a fraction string" do
+      assert Multiplier.new("3/4") == %Multiplier{numerator: 3, denominator: 4}
+      assert Multiplier.new("4/4") == %Multiplier{numerator: 1, denominator: 1}
+    end
+  end
 
   describe inspect(&Multiplier.new/2) do
     test "takes integral numerator and denominator" do
@@ -27,18 +46,6 @@ defmodule Satie.MultiplierTest do
     end
   end
 
-  describe inspect(&Multiplier.new/1) do
-    test "denominator defaults to 1" do
-      assert Multiplier.new(3) == %Multiplier{numerator: 3, denominator: 1}
-    end
-
-    test "can be created from another fractional type" do
-      assert Multiplier.new(Duration.new(1, 4)) == %Multiplier{numerator: 1, denominator: 4}
-      assert Multiplier.new(Multiplier.new(2, 4)) == %Multiplier{numerator: 1, denominator: 2}
-      assert Multiplier.new(Offset.new(1, 3)) == %Multiplier{numerator: 1, denominator: 3}
-    end
-  end
-
   describe "arithmetic" do
     test "against a duration" do
       m = Multiplier.new(1, 5)
@@ -48,6 +55,16 @@ defmodule Satie.MultiplierTest do
       assert is_struct(Multiplier.subtract(m, d), Multiplier)
       assert is_struct(Multiplier.multiply(m, d), Duration)
       assert is_struct(Multiplier.divide(m, d), Multiplier)
+    end
+
+    test "against a fraction" do
+      m = Multiplier.new(1, 5)
+      f = Fraction.new(1, 8)
+
+      assert is_struct(Multiplier.add(m, f), Fraction)
+      assert is_struct(Multiplier.subtract(m, f), Fraction)
+      assert is_struct(Multiplier.multiply(m, f), Fraction)
+      assert is_struct(Multiplier.divide(m, f), Fraction)
     end
 
     test "against an integer" do
@@ -75,6 +92,12 @@ defmodule Satie.MultiplierTest do
       assert is_struct(Multiplier.subtract(m, o), Multiplier)
       assert is_struct(Multiplier.multiply(m, o), Multiplier)
       assert is_struct(Multiplier.divide(m, o), Multiplier)
+    end
+  end
+
+  describe_function &Inspect.inspect/2 do
+    test "returns the multiplier formatted for IEx" do
+      assert Multiplier.new(3, 6) |> inspect() == "#Satie.Multiplier<1/2>"
     end
   end
 end

--- a/test/satie/offset_test.exs
+++ b/test/satie/offset_test.exs
@@ -1,15 +1,21 @@
 defmodule Satie.OffsetTest do
   use ExUnit.Case, async: true
+  import DescribeFunction
 
-  alias Satie.{Duration, Multiplier, Offset}
+  alias Satie.{Duration, Fraction, Multiplier, Offset}
 
   doctest Offset
 
-  describe inspect(&Offset.new/1) do
+  describe_function &Offset.new/1 do
     test "can be created from another fractional type" do
       assert Offset.new(Duration.new(1, 4)) == %Offset{numerator: 1, denominator: 4}
+      assert Offset.new(Fraction.new(1, 4)) == %Offset{numerator: 1, denominator: 4}
       assert Offset.new(Multiplier.new(2, 4)) == %Offset{numerator: 1, denominator: 2}
       assert Offset.new(Offset.new(1, 3)) == %Offset{numerator: 1, denominator: 3}
+    end
+
+    test "can be created from a fraction string" do
+      assert Offset.new("1/4") == %Offset{numerator: 1, denominator: 4}
     end
   end
 
@@ -107,6 +113,16 @@ defmodule Satie.OffsetTest do
       assert is_struct(Offset.subtract(o, d), Offset)
       assert is_struct(Offset.multiply(o, d), Offset)
       assert is_struct(Offset.divide(o, d), Offset)
+    end
+
+    test "against a fraction" do
+      o = Offset.new(1, 3)
+      f = Fraction.new(1, 8)
+
+      assert is_struct(Offset.add(o, f), Fraction)
+      assert is_struct(Offset.subtract(o, f), Duration)
+      assert is_struct(Offset.multiply(o, f), Fraction)
+      assert is_struct(Offset.divide(o, f), Fraction)
     end
 
     test "against an integer" do

--- a/test/satie/time_signature_test.exs
+++ b/test/satie/time_signature_test.exs
@@ -2,13 +2,12 @@ defmodule Satie.TimeSignatureTest do
   use ExUnit.Case, async: true
   import DescribeFunction
 
-  alias Satie.{Rest, TimeSignature}
+  alias Satie.{Fraction, Rest, TimeSignature}
 
   describe_function &TimeSignature.new/1 do
     test "parses a valid string into a time signature" do
       assert TimeSignature.new("\\time 3/16") == %TimeSignature{
-               numerator: 3,
-               denominator: 16,
+               fraction: Fraction.new(3, 16),
                components: [
                  before: ["\\time 3/16"]
                ]
@@ -17,8 +16,7 @@ defmodule Satie.TimeSignatureTest do
 
     test "doesn't require the `\\time` at the beginning" do
       assert TimeSignature.new("7/16") == %TimeSignature{
-               numerator: 7,
-               denominator: 16,
+               fraction: Fraction.new(7, 16),
                components: [
                  before: ["\\time 7/16"]
                ]
@@ -35,8 +33,7 @@ defmodule Satie.TimeSignatureTest do
   describe_function &TimeSignature.new/2 do
     test "creates a new time signature from two integers" do
       assert TimeSignature.new(3, 4) == %TimeSignature{
-               numerator: 3,
-               denominator: 4,
+               fraction: Fraction.new(3, 4),
                components: [
                  before: ["\\time 3/4"]
                ]
@@ -45,8 +42,7 @@ defmodule Satie.TimeSignatureTest do
 
     test "doesn't reduce a fraction" do
       assert TimeSignature.new(4, 8) == %TimeSignature{
-               numerator: 4,
-               denominator: 8,
+               fraction: Fraction.new(4, 8),
                components: [
                  before: ["\\time 4/8"]
                ]


### PR DESCRIPTION
Add `Fraction`
---

The `Fraction` struct represents a non-reduced fraction.

This PR adds the struct, as well as constsructors and arithmetic
operators to bring it to parity with the other fractional types
(duration, multiplier, offset)

Add the ability to parse a fraction from a string of the form "xx/yy"
and extend that functionality to offsets and multipliers

Extract shared fractional arithmetic to `Satie.Fractional.Math`

Also
---

* Use `Fraction` in `TimeSignature` instead of storing a
  numerator/denominator
* Rewrite `MultiMeasureRest` to use a `Multiplier` instead of a `TimeSignature`