### PR TITLE
Use Lilypond.Parser for initializers still using regex

### DIFF
--- a/lib/satie/interval.ex
+++ b/lib/satie/interval.ex
@@ -6,6 +6,7 @@ defmodule Satie.Interval do
   defstruct ~w(interval_class name size polarity octaves quality semitones staff_spaces)a
 
   alias Satie.IntervalClass
+  alias Satie.Lilypond.Parser
   import Satie.IntervalHelpers
 
   import Satie.Helpers,
@@ -16,13 +17,9 @@ defmodule Satie.Interval do
     ]
 
   def new(interval) when is_bitstring(interval) do
-    case Regex.named_captures(interval_regex(), interval) do
-      nil ->
-        {:error, :interval_new, interval}
-
-      captures ->
+    case Parser.interval().(interval) do
+      {:ok, captures, ""} ->
         captures
-        |> Enum.into(%{}, fn {k, v} -> {String.to_atom(k), v} end)
         |> parse_polarity()
         |> parse_size()
         |> validate_quality(:interval)
@@ -41,6 +38,9 @@ defmodule Satie.Interval do
             |> calculate_staff_spaces()
             |> then(&struct(__MODULE__, &1))
         end)
+
+      _ ->
+        {:error, :interval_new, interval}
     end
   end
 

--- a/lib/satie/interval_class.ex
+++ b/lib/satie/interval_class.ex
@@ -8,14 +8,12 @@ defmodule Satie.IntervalClass do
   import Satie.Helpers, only: [normalize_size: 1]
   import Satie.IntervalHelpers
 
-  def new(interval_class) when is_bitstring(interval_class) do
-    case Regex.named_captures(interval_regex(), interval_class) do
-      nil ->
-        {:error, :interval_class_new, interval_class}
+  alias Satie.Lilypond.Parser
 
-      captures ->
+  def new(interval_class) when is_bitstring(interval_class) do
+    case Parser.interval().(interval_class) do
+      {:ok, captures, ""} ->
         captures
-        |> Enum.into(%{}, fn {k, v} -> {String.to_atom(k), v} end)
         |> parse_polarity()
         |> parse_size()
         |> validate_quality(:interval_class)
@@ -30,6 +28,9 @@ defmodule Satie.IntervalClass do
             |> build_name()
             |> then(&struct(__MODULE__, &1))
         end)
+
+      _ ->
+        {:error, :interval_class_new, interval_class}
     end
   end
 

--- a/lib/satie/interval_helpers.ex
+++ b/lib/satie/interval_helpers.ex
@@ -24,15 +24,6 @@ defmodule Satie.IntervalHelpers do
 
   alias Satie.Helpers
 
-  def interval_regex do
-    ~r/^
-      (?<polarity>[-+]?)
-      (?<quality>m|M|P|d+|A+)
-      (?<quartertone>[~+]?)
-      (?<size>\d+)
-    $/x
-  end
-
   def is_perfect_unison?(%{quality: "P", size: 1, quartertone: ""}), do: true
   def is_perfect_unison?(_), do: false
 

--- a/lib/satie/multi_measure_rest.ex
+++ b/lib/satie/multi_measure_rest.ex
@@ -4,17 +4,16 @@ defmodule Satie.MultiMeasureRest do
   """
   defstruct [:multiplier, :measures]
 
+  alias Satie.Lilypond.Parser
   alias Satie.Multiplier
 
-  @re ~r/^(R1\s*\*\s*)?(?<multiplier>\d+\/\d+)\s*\*\s*(?<measures>\d+)$/
-
   def new(multi_measure_rest) when is_bitstring(multi_measure_rest) do
-    case Regex.named_captures(@re, multi_measure_rest) do
-      %{"multiplier" => multiplier, "measures" => measures} ->
+    case Parser.multi_measure_rest().(multi_measure_rest) do
+      {:ok, [multiplier, measures], ""} ->
         {measures, ""} = Integer.parse(measures)
-        new(Multiplier.new(multiplier), measures)
+        new(multiplier, measures)
 
-      nil ->
+      _ ->
         {:error, :multi_measure_rest_new, multi_measure_rest}
     end
   end

--- a/lib/satie/time_signature.ex
+++ b/lib/satie/time_signature.ex
@@ -4,6 +4,7 @@ defmodule Satie.TimeSignature do
   """
 
   alias Satie.Fraction
+  alias Satie.Lilypond.Parser
 
   use Satie.Attachable,
     fields: [:fraction],
@@ -11,16 +12,14 @@ defmodule Satie.TimeSignature do
     priority: 3,
     has_direction: false
 
-  @re ~r/^(\\time\s+)?(?<numerator>\d+)\/(?<denominator>\d+)$/
-
   def new(time_signature) when is_bitstring(time_signature) do
-    case Regex.named_captures(@re, time_signature) do
-      %{"numerator" => numerator, "denominator" => denominator} ->
+    case Parser.time_signature().(time_signature) do
+      {:ok, [numerator, denominator], ""} ->
         {n, ""} = Integer.parse(numerator)
         {d, ""} = Integer.parse(denominator)
         new(n, d)
 
-      nil ->
+      _ ->
         {:error, :time_signature_new, time_signature}
     end
   end


### PR DESCRIPTION
Use Lilypond.Parser for initializers still using regex
---

Replace use of `Regex.named_captures` with `Lilypond.Parser` functions
in the `.new` implementations for

* Interval
* IntervalClass
* MultiMeasureRest
* TimeSignature
