### PR TITLE
Cleanup TimespanList implementations

### DIFF
--- a/lib/satie/timespan_list/explode.ex
+++ b/lib/satie/timespan_list/explode.ex
@@ -1,0 +1,79 @@
+defmodule Satie.TimespanList.Explode do
+  @moduledoc false
+
+  alias Satie.{Timespan, TimespanList}
+
+  def explode(%TimespanList{timespans: timespans} = timespan_list, list_count \\ nil)
+      when is_nil(list_count) or is_integer(list_count) do
+    global_timespan = TimespanList.timespan(timespan_list)
+
+    timespans
+    |> Enum.reduce([], fn timespan, results ->
+      [non_overlapping_sets, overlapping_sets] =
+        partition_by_overlapping(results, timespan, global_timespan)
+
+      insert_timespan(timespan, non_overlapping_sets, overlapping_sets, results, list_count)
+    end)
+    |> Enum.map(&Enum.reverse/1)
+    |> Enum.map(&TimespanList.new/1)
+  end
+
+  defp insert_timespan(timespan, non_overlapping_sets, _overlapping_sets, results, nil) do
+    case non_overlapping_sets do
+      [] -> append_new_result(results, timespan)
+      _ -> insert_into_lowest_overlap(non_overlapping_sets, results, timespan)
+    end
+  end
+
+  defp insert_timespan(timespan, non_overlapping_sets, overlapping_sets, results, list_count) do
+    case non_overlapping_sets do
+      [] ->
+        case length(results) < list_count do
+          true -> append_new_result(results, timespan)
+          false -> insert_into_lowest_overlap(overlapping_sets, results, timespan)
+        end
+
+      _ ->
+        insert_into_lowest_overlap(non_overlapping_sets, results, timespan)
+    end
+  end
+
+  defp insert_into_lowest_overlap(sets, results, timespan) do
+    [{index, _, _, _} | _] = sets
+    List.update_at(results, index, &[timespan | &1])
+  end
+
+  defp append_new_result(results, timespan), do: results ++ [[timespan]]
+
+  defp partition_by_overlapping([], _timespan, _global_timespan), do: [[], []]
+
+  defp partition_by_overlapping(timespan_sets, %Timespan{} = timespan, global_timespan) do
+    grouped_sets =
+      timespan_sets
+      |> Enum.with_index()
+      |> Enum.map(fn {set, index} ->
+        {index, set, calculate_overlap_length(timespan, set),
+         calculate_overlap_length(global_timespan, set)}
+      end)
+      |> Enum.group_by(fn {_, _, local_overlap, _} -> local_overlap > 0 end)
+
+    [false, true]
+    |> Enum.map(&Map.get(grouped_sets, &1, []))
+    |> Enum.map(fn set ->
+      Enum.sort_by(set, fn {_, _, local_overlap, global_overlap} ->
+        [local_overlap, global_overlap]
+      end)
+    end)
+  end
+
+  defp calculate_overlap_length(%Timespan{} = timespan1, timespans) when is_list(timespans) do
+    Enum.map(timespans, &calculate_overlap_length(&1, timespan1))
+    |> Enum.sum()
+  end
+
+  defp calculate_overlap_length(%Timespan{} = timespan1, %Timespan{} = timespan2) do
+    Timespan.intersection(timespan1, timespan2).timespans
+    |> Enum.map(&Timespan.length/1)
+    |> Enum.sum()
+  end
+end

--- a/lib/satie/timespan_list/to_lilypond.ex
+++ b/lib/satie/timespan_list/to_lilypond.ex
@@ -1,0 +1,151 @@
+defmodule Satie.TimespanList.ToLilypond do
+  @moduledoc false
+
+  @spacer ""
+  @for Satie.TimespanList
+
+  alias Satie.Timespan
+
+  import Satie.Lilypond.OutputHelpers
+
+  def to_lilypond(%@for{timespans: timespans} = timespan_list, opts) do
+    sorted_offsets =
+      Enum.map(timespans, &Timespan.to_tuple_pair/1)
+      |> List.flatten()
+      |> Enum.sort_by(fn {n, d} -> n / d end)
+      |> Enum.uniq()
+
+    {{min_n, min_d}, {max_n, max_d}} =
+      case Keyword.get(opts, :range, nil) do
+        nil -> Enum.min_max(sorted_offsets)
+        a..b -> {{a, 1}, {b, 1}}
+      end
+
+    min = min_n / min_d
+    max = max_n / max_d
+
+    mapper = mapper_between_ranges({min, max}, {1, 106})
+
+    indexed_sublists =
+      timespan_list
+      |> @for.explode()
+      |> Enum.map(& &1.timespans)
+      |> Enum.with_index()
+
+    output_rows =
+      indexed_sublists
+      |> Enum.map_join("\n\n", fn {sublist, index} ->
+        generate_output_row(sublist, index, mapper)
+      end)
+
+    output_dashes =
+      indexed_sublists
+      |> Enum.drop(1)
+      |> Enum.map_join("\n\n", &generate_output_dashes(&1, mapper))
+
+    [
+      "\\markup \\column {",
+      build_labels(sorted_offsets, mapper),
+      build_postscript(output_rows, output_dashes),
+      "}"
+    ]
+    |> List.flatten()
+    |> Enum.join("\n")
+  end
+
+  defp build_postscript(rows, dashes) do
+    [
+      "  \\postscript #\"",
+      "  0.2 setlinewidth",
+      @spacer,
+      rows,
+      build_dashes(dashes),
+      "  \""
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp build_dashes(""), do: nil
+
+  defp build_dashes(dashes) do
+    [
+      @spacer,
+      "  0.1 setlinewidth",
+      "  [ 0.4 0.4 ] 0 setdash",
+      @spacer,
+      dashes
+    ]
+  end
+
+  defp build_labels(offsets, mapper) do
+    [
+      "\\overlay {",
+      generate_offset_labels(offsets, mapper),
+      "}"
+    ]
+    |> indent()
+  end
+
+  defp generate_offset_labels(offsets, mapper) do
+    Enum.map_join(offsets, "\n", fn {n, d} ->
+      x = mapper.(n / d)
+
+      [
+        "\\translate #'(#{x} . 1)",
+        "\\fontsize #-2 \\center-align \\fraction #{n} #{d}"
+      ]
+      |> indent()
+      |> Enum.join("\n")
+    end)
+  end
+
+  defp generate_output_row(timespans, index, mapper) do
+    y = 1 - 3 * index
+
+    timespans
+    |> Enum.map(&Timespan.to_tuple_pair/1)
+    |> Enum.map_join("\n", fn [{start_n, start_d}, {stop_n, stop_d}] ->
+      start_x = mapper.(start_n / start_d)
+      stop_x = mapper.(stop_n / stop_d)
+
+      [
+        {start_x, y - 0.5, start_x, y + 0.5},
+        {stop_x, y - 0.5, stop_x, y + 0.5},
+        {start_x, y / 1, stop_x, y / 1}
+      ]
+      |> Enum.map_join("\n", &draw_line/1)
+    end)
+  end
+
+  defp generate_output_dashes({timespans, index}, mapper) do
+    y = 2 - 3 * index
+
+    timespans
+    |> Enum.map(&Timespan.to_tuple_pair/1)
+    |> List.flatten()
+    |> Enum.map_join("\n", fn {n, d} ->
+      x = mapper.(n / d)
+
+      draw_line({x, 2.0, x, y / 1})
+    end)
+  end
+
+  defp draw_line({x1, y1, x2, y2}) do
+    """
+    #{x1} #{y1} moveto
+    #{x2} #{y2} lineto
+    stroke
+    """
+    |> String.trim_trailing()
+    |> indent()
+  end
+
+  defp mapper_between_ranges({in_start, in_stop}, {out_start, out_stop}) do
+    fn input ->
+      (out_start + (out_stop - out_start) / (in_stop - in_start) * (input - in_start))
+      |> Float.round(2)
+    end
+  end
+end

--- a/test/files/timespan_list.ly
+++ b/test/files/timespan_list.ly
@@ -33,15 +33,6 @@
   7.56 1.0 moveto
   60.06 1.0 lineto
   stroke
-  86.31 0.5 moveto
-  86.31 1.5 lineto
-  stroke
-  106.0 0.5 moveto
-  106.0 1.5 lineto
-  stroke
-  86.31 1.0 moveto
-  106.0 1.0 lineto
-  stroke
 
   23.97 -2.5 moveto
   23.97 -1.5 lineto
@@ -71,6 +62,15 @@
   1.0 -5.0 moveto
   33.81 -5.0 lineto
   stroke
+  86.31 -5.5 moveto
+  86.31 -4.5 lineto
+  stroke
+  106.0 -5.5 moveto
+  106.0 -4.5 lineto
+  stroke
+  86.31 -5.0 moveto
+  106.0 -5.0 lineto
+  stroke
 
   0.1 setlinewidth
   [ 0.4 0.4 ] 0 setdash
@@ -93,6 +93,12 @@
   stroke
   33.81 2.0 moveto
   33.81 -4.0 lineto
+  stroke
+  86.31 2.0 moveto
+  86.31 -4.0 lineto
+  stroke
+  106.0 2.0 moveto
+  106.0 -4.0 lineto
   stroke
   "
 }

--- a/test/files/timespan_list_ranged.ly
+++ b/test/files/timespan_list_ranged.ly
@@ -33,15 +33,6 @@
   18.5 1.0 moveto
   46.5 1.0 lineto
   stroke
-  60.5 0.5 moveto
-  60.5 1.5 lineto
-  stroke
-  71.0 0.5 moveto
-  71.0 1.5 lineto
-  stroke
-  60.5 1.0 moveto
-  71.0 1.0 lineto
-  stroke
 
   27.25 -2.5 moveto
   27.25 -1.5 lineto
@@ -71,6 +62,15 @@
   15.0 -5.0 moveto
   32.5 -5.0 lineto
   stroke
+  60.5 -5.5 moveto
+  60.5 -4.5 lineto
+  stroke
+  71.0 -5.5 moveto
+  71.0 -4.5 lineto
+  stroke
+  60.5 -5.0 moveto
+  71.0 -5.0 lineto
+  stroke
 
   0.1 setlinewidth
   [ 0.4 0.4 ] 0 setdash
@@ -93,6 +93,12 @@
   stroke
   32.5 2.0 moveto
   32.5 -4.0 lineto
+  stroke
+  60.5 2.0 moveto
+  60.5 -4.0 lineto
+  stroke
+  71.0 2.0 moveto
+  71.0 -4.0 lineto
   stroke
   "
 }

--- a/test/satie/timespan_list_test.exs
+++ b/test/satie/timespan_list_test.exs
@@ -5,25 +5,6 @@ defmodule Satie.TimespanListTest do
 
   doctest TimespanList
 
-  describe inspect(&TimespanList.sorted_into_non_overlapping_sublists/1) do
-    test "divides a list of timespans into sublists, each of which contains only non-overlapping timespans" do
-      timespan_list =
-        TimespanList.new([
-          Timespan.new(0, 16),
-          Timespan.new(5, 12),
-          Timespan.new(-2, 8),
-          Timespan.new(15, 20),
-          Timespan.new(24, 30)
-        ])
-
-      assert TimespanList.sorted_into_non_overlapping_sublists(timespan_list) == [
-               [Timespan.new(0, 16), Timespan.new(24, 30)],
-               [Timespan.new(5, 12), Timespan.new(15, 20)],
-               [Timespan.new(-2, 8)]
-             ]
-    end
-  end
-
   describe inspect(&TimespanList.well_formed?/1) do
     test "returns true if all timespans are well formed" do
       timespan_list =


### PR DESCRIPTION
## Cleanup TimespanList implementations

- Extract `to_lilypond` and `explode` to helper modules
- Remove `sorted_into_non_overlapping_sublists` and use `explode` instead
- Refactor Offset validation for `split`