### PR TITLE
Add Satie.Markup

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,14 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [
+    build_entity: 1,
+    build_entity: 2,
+    build_entity_with_overrides: 2,
+    build_entity_with_overrides: 3,
+    build_function: 1,
+    build_function: 2,
+    build_function_with_overrides: 2,
+    build_function_with_overrides: 3
+  ]
 ]

--- a/lib/satie/lilypond/output_helpers.ex
+++ b/lib/satie/lilypond/output_helpers.ex
@@ -14,6 +14,8 @@ defmodule Satie.Lilypond.OutputHelpers do
 
   def indent(indentable, depth \\ 1)
 
+  def indent(nil, _), do: nil
+
   def indent(s, depth) when is_bitstring(s) do
     s
     |> String.split("\n", trim: true)

--- a/lib/satie/markup.ex
+++ b/lib/satie/markup.ex
@@ -1,0 +1,239 @@
+defmodule Satie.Markup do
+  @moduledoc """
+  Models arbitrarily nested markup
+  """
+
+  alias __MODULE__.ComponentHelpers
+  require __MODULE__.FunctionBuilder
+  import __MODULE__.FunctionBuilder
+
+  use Satie.Attachable, fields: [:content]
+
+  def new(content) do
+    %__MODULE__{
+      content: content
+    }
+    |> ComponentHelpers.build_component()
+  end
+
+  ###########
+  ## FONT ##
+  ###########
+
+  build_function :bold
+  build_function :caps
+  build_function :dynamic
+  build_function "figured-bass"
+  build_function :finger
+  build_function "fontCaps"
+  build_function :huge
+  build_function :italic
+  build_function :large
+  build_function :larger
+  build_function :magnify, :sz
+  build_function :medium
+  build_function "normal-text"
+  build_function :normalsize
+  build_function :number
+  build_function :roman
+  build_function :sans
+  build_function :simple
+  build_function :small
+  build_function "smallCaps"
+  build_function :smaller
+  build_function :teeny
+  build_function :text
+  build_function :tiny
+  build_function :typewriter
+  build_function :upright
+
+  build_function_with_overrides "abs-fontsize", size, ~w(baseline-skip word-space)
+  build_function_with_overrides :box, ~w(box-padding font-size thickness)
+  build_function_with_overrides :fontsize, increment, ~w(baseline-skip word-space font-size)
+  build_function_with_overrides "normal-size-sub", ~w(font-size)
+  build_function_with_overrides "normal-size-super", ~w(font-size)
+  build_function_with_overrides :overtie, ~w(shorten-pair height-limit direction offset thickness)
+  build_function_with_overrides :sub, ~w(font-size)
+  build_function_with_overrides :super, ~w(font-size)
+  build_function_with_overrides :tie, ~w(shorten-pair height-limit direction offset thickness)
+  build_function_with_overrides :underline, ~w(underline-skip underline-shift offset thickness)
+
+  build_function_with_overrides :undertie,
+                                ~w(shorten-pair height-limit direction offset thickness)
+
+  ############
+  ## ALIGN ##
+  ############
+
+  build_function "center-align"
+  build_function "center-column"
+  build_function :column
+  build_function :concat
+  build_function "general-align", [axis, dir]
+  build_function :halign, dir
+  build_function "hcenter-in", length
+  build_function "left-align"
+  build_function :lower, amount
+  build_function :overlay
+  build_function :pad, amount
+  build_function "pad-around", amount
+  build_function "pad-to-box", [x_ext, y_ext]
+  build_function "pad-x", amount
+  build_function :raise, amount
+  build_function "right-align"
+  build_function :rotate, ang
+  build_function :translate, offset
+  build_function :vcenter
+
+  build_entity :hspace, amount
+  build_entity :vspace, amount
+
+  build_function_with_overrides "dir-column", ~w(baseline-skip direction)
+  build_function_with_overrides "fill-line", ~w(line-width word-space text-direction)
+  build_function_with_overrides :justify, ~w(text-direction word-space line-width baseline-skip)
+  build_function_with_overrides "justify-line", ~w(text-direction word-space line-width)
+  build_function_with_overrides "left-column", ~w(baseline-skip)
+  build_function_with_overrides "line", ~w(text-direction word-space)
+  build_function_with_overrides "right-column", ~w(baseline-skip)
+  build_function_with_overrides "translate-scaled", offset, ~w(font-size)
+  build_function_with_overrides :wordwrap, ~w(text-direction word-space line-width baseline-skip)
+
+  ##############
+  ## GRAPHIC ##
+  ##############
+
+  build_entity "arrow-head", [axis, direction, filled]
+  build_entity :beam, [width, slope, thickness]
+  build_entity "draw-circle", [radius, thickness, filled]
+  build_entity "eps-file", [axis, size, file_name]
+  build_entity "filled-box", [xext, yext, blot]
+
+  build_entity_with_overrides "draw-dashed-line", dest, ~w(full-length phase off on thickness)
+  build_entity_with_overrides "draw-dotted-line", dest, ~w(phase off thickness)
+  build_entity_with_overrides "draw-hline", ~w(span-factor line-width draw-line-markup)
+  build_entity_with_overrides "draw-line", dest, ~w(thickness)
+
+  build_entity_with_overrides "draw-squiggle-line",
+                              [sq_length, dest, eq_end],
+                              ~w(orientation height angularity thickness)
+
+  build_entity_with_overrides :triangle, filled, ~w(thickness font-size extroversion)
+
+  build_function :bracket
+  build_function :hbracket
+  build_function :scale, factor_pair
+  build_function "with-url", url
+
+  build_function_with_overrides :circle, ~w(circle-padding font-size thickness)
+  build_function_with_overrides :ellipse, ~w(x-padding y-padding font-size thickness)
+  build_function_with_overrides :oval, ~w(x-padding y-padding font-size thickness)
+
+  build_function_with_overrides :parenthesize,
+                                ~w(width line-thickness thickness size padding angularity)
+
+  build_function_with_overrides "rounded-box", ~w(box-padding font-size corner-radius thickness)
+
+  ############
+  ## MUSIC ##
+  ############
+
+  build_entity :coda
+  build_entity "customTabClef", [num_strings, staff_space]
+  build_entity :doubleflat
+  build_entity :doublesharp
+  build_entity :flat
+  build_entity :musicglyph, glyph_name
+  build_entity :natural
+  build_entity :segno
+  build_entity :semiflat
+  build_entity :semisharp
+  build_entity :sesquiflat
+  build_entity :sesquisharp
+  build_entity :sharp
+  build_entity :varcoda
+
+  build_entity_with_overrides :fermata, ~w(direction)
+
+  build_entity_with_overrides "multi-measure-rest-with-overrides",
+                              duration_scale,
+                              ~w(multi-measure-rest-number width expand-limit hair-thickness thick-thickness word-space style font-size)
+
+  build_entity_with_overrides :note,
+                              [duration, dir],
+                              ~w(style dots-direction flag-style font-size)
+
+  build_entity_with_overrides "note-by-number",
+                              [log, dot_count, dir],
+                              ~w(style dots-direction flag-style font-size)
+
+  build_entity_with_overrides :rest,
+                              [duration],
+                              ~w(multi-measure-rest-number width expand-limit hair-thickness thick-thickness word-space style font-size ledgers)
+
+  build_entity_with_overrides "rest-by-number", [log, dot_count], ~w(style ledgers font-size)
+
+  build_entity_with_overrides "tied-lyric", str, ~w(word-space)
+
+  ############
+  ## OTHER ##
+  ############
+
+  build_entity :eyeglasses
+  build_entity "left-brace", size
+  build_entity :markalphabet, num
+  build_entity :markletter, num
+  build_entity :null
+  build_entity :pattern, [count, axis, space, pattern]
+  build_entity "right-brace", size
+  build_entity :strut
+  build_entity "verbatim-file", name
+
+  build_entity_with_overrides "backslashed-digit", ~w(thickness font-size)
+  build_entity_with_overrides "slashed-digit", ~w(thickness font-size)
+
+  build_function :transparent
+  build_function "with-color", color
+
+  build_function_with_overrides :whiteout, ~w(thickness style)
+
+  # TODO:
+  # FONT
+  # - replace
+  # - with-string-transformer
+  # ALIGN
+  # - align-on-other
+  # - combine
+  # - fill-with-pattern
+  # - justify-field
+  # - justify-string
+  # - put-adjacent
+  # - wordwrap-field
+  # - wordwrap-string
+  # GRAPHIC
+  # - path
+  # - polygon
+  # - postscript
+  # MUSIC
+  # - accidental
+  # - compound-meter
+  # - rhythm
+  # - score
+  # OTHER
+  # - auto-footnote
+  # - char
+  # - first-visible
+  # - footnote
+  # - fraction
+  # - fromproperty
+  # - lookup
+  # - on-the-fly
+  # - override
+  # - page-link
+  # - page-ref
+  # - property-recursive
+  # - stencil
+  # - with-dimensions-from
+  # - with-dimensions
+  # - with-link
+  # - with-outline
+end

--- a/lib/satie/markup/component_helpers.ex
+++ b/lib/satie/markup/component_helpers.ex
@@ -1,0 +1,108 @@
+defmodule Satie.Markup.ComponentHelpers do
+  @moduledoc """
+    Helper functions to construct attachable components for markup structs
+  """
+
+  alias Satie.Markup
+
+  import Satie.Lilypond.OutputHelpers
+
+  def build_component(%Markup{} = markup) do
+    component = do_build_component(markup)
+
+    %Markup{markup | components: [after: [component]]}
+  end
+
+  defp do_build_component(%Markup{content: content}) when is_bitstring(content) do
+    [
+      "\\markup {",
+      indent(content),
+      "}"
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp do_build_component(%Markup{content: content}) do
+    [
+      "\\markup {",
+      indent(do_build_component(content)),
+      "}"
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp do_build_component(components) when is_list(components) do
+    Enum.map_join(components, "\n", &do_build_component/1)
+  end
+
+  defp do_build_component(%{command: _, content: content} = map) do
+    [
+      build_overrides(map),
+      build_command(map),
+      indent(do_build_component(content)),
+      "}"
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp do_build_component(%{command: _} = map) do
+    [
+      build_overrides(map),
+      build_entity(map)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
+  end
+
+  defp do_build_component(content) when is_bitstring(content), do: inspect(content)
+
+  defp build_command(%{} = map) do
+    "#{build_entity(map)} {"
+  end
+
+  defp build_entity(%{command: command, arguments: arguments}) do
+    arguments =
+      arguments
+      |> Enum.map_join(" ", &format_argument/1)
+
+    "\\#{command} #{arguments}"
+  end
+
+  defp build_entity(%{command: command, argument: argument}) do
+    "\\#{command} #{format_argument(argument)}"
+  end
+
+  defp build_entity(%{command: command}) do
+    "\\#{command}"
+  end
+
+  defp format_argument(true), do: "##t"
+  defp format_argument(false), do: "##f"
+  defp format_argument(arg) when is_atom(arg), do: "##{to_string(arg)}"
+  defp format_argument({a, b}), do: "#'(#{a} . #{b})"
+  defp format_argument(%Satie.Duration{} = duration), do: "{#{Satie.to_lilypond(duration)}}"
+  defp format_argument(%Satie.MultiMeasureRest{measures: measures}), do: "{1*#{measures}}"
+  defp format_argument(%{command: _} = arg), do: do_build_component(arg)
+  defp format_argument(arg), do: "##{inspect(arg)}"
+
+  defp build_overrides(%{overrides: []}), do: nil
+
+  defp build_overrides(%{overrides: overrides}) when is_map(overrides) do
+    [
+      "\\override #'(",
+      Enum.map(overrides, fn {k, v} ->
+        indent("(#{k} . #{v})")
+      end),
+      ")"
+    ]
+    |> List.flatten()
+    |> Enum.join("\n")
+  end
+
+  defp build_overrides(_), do: nil
+end

--- a/lib/satie/markup/function_builder.ex
+++ b/lib/satie/markup/function_builder.ex
@@ -1,0 +1,222 @@
+defmodule Satie.Markup.FunctionBuilder do
+  @moduledoc """
+    Macros to construct Markup functions
+  """
+
+  alias __MODULE__
+
+  defmacro build_entity(command) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)() do
+        %{
+          command: to_string(unquote(command))
+        }
+      end
+    end
+  end
+
+  defmacro build_entity(command, argnames) when is_list(argnames) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(unquote_splicing(argnames)) do
+        %{
+          command: to_string(unquote(command)),
+          arguments: [unquote_splicing(argnames)]
+        }
+      end
+    end
+  end
+
+  defmacro build_entity(command, argname) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(unquote(argname)) do
+        %{
+          command: to_string(unquote(command)),
+          argument: unquote(argname)
+        }
+      end
+    end
+  end
+
+  defmacro build_entity_with_overrides(command, override_keys) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(overrides \\ []) do
+        with {:ok, overrides} <-
+               FunctionBuilder.validate_overrides(
+                 overrides,
+                 unquote(override_keys),
+                 unquote(function_name)
+               ) do
+          %{
+            command: to_string(unquote(command)),
+            overrides: overrides
+          }
+        end
+      end
+    end
+  end
+
+  defmacro build_entity_with_overrides(command, argnames, override_keys) when is_list(argnames) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(unquote_splicing(argnames), overrides \\ []) do
+        with {:ok, overrides} <-
+               FunctionBuilder.validate_overrides(
+                 overrides,
+                 unquote(override_keys),
+                 unquote(function_name)
+               ) do
+          %{
+            command: to_string(unquote(command)),
+            arguments: [unquote_splicing(argnames)],
+            overrides: overrides
+          }
+        end
+      end
+    end
+  end
+
+  defmacro build_entity_with_overrides(command, argname, override_keys) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(unquote(argname), overrides \\ []) do
+        with {:ok, overrides} <-
+               FunctionBuilder.validate_overrides(
+                 overrides,
+                 unquote(override_keys),
+                 unquote(function_name)
+               ) do
+          %{
+            command: to_string(unquote(command)),
+            argument: unquote(argname),
+            overrides: overrides
+          }
+        end
+      end
+    end
+  end
+
+  defmacro build_function(command) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(content) do
+        %{
+          command: to_string(unquote(command)),
+          content: content
+        }
+      end
+    end
+  end
+
+  defmacro build_function(command, argnames) when is_list(argnames) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(content, unquote_splicing(argnames)) do
+        %{
+          command: to_string(unquote(command)),
+          arguments: [unquote_splicing(argnames)],
+          content: content
+        }
+      end
+    end
+  end
+
+  defmacro build_function(command, argname) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(content, unquote(argname)) do
+        %{
+          command: to_string(unquote(command)),
+          argument: unquote(argname),
+          content: content
+        }
+      end
+    end
+  end
+
+  defmacro build_function_with_overrides(command, override_keys) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(content, overrides \\ []) do
+        with {:ok, overrides} <-
+               FunctionBuilder.validate_overrides(
+                 overrides,
+                 unquote(override_keys),
+                 unquote(function_name)
+               ) do
+          %{
+            command: to_string(unquote(command)),
+            overrides: overrides,
+            content: content
+          }
+        end
+      end
+    end
+  end
+
+  defmacro build_function_with_overrides(command, argname, override_keys) do
+    function_name = command_to_function_name(command)
+
+    quote do
+      def unquote(function_name)(content, unquote(argname), overrides \\ []) do
+        with {:ok, overrides} <-
+               FunctionBuilder.validate_overrides(
+                 overrides,
+                 unquote(override_keys),
+                 unquote(function_name)
+               ) do
+          %{
+            command: to_string(unquote(command)),
+            overrides: FunctionBuilder.process_overrides(overrides),
+            argument: unquote(argname),
+            content: content
+          }
+        end
+      end
+    end
+  end
+
+  def validate_overrides([], _valid_keys, _function_name), do: {:ok, []}
+
+  def validate_overrides(overrides, valid_keys, function_name) do
+    overrides = process_overrides(overrides)
+
+    case Enum.filter(Map.keys(overrides), &(&1 not in valid_keys)) do
+      [] -> {:ok, overrides}
+      invalid_keys -> {:error, "invalid override keys given to #{function_name}", invalid_keys}
+    end
+  end
+
+  defp command_to_function_name(command) when is_atom(command), do: command
+
+  defp command_to_function_name(command) when is_bitstring(command) do
+    command
+    |> Macro.underscore()
+    |> String.replace("-", "_")
+    |> String.to_atom()
+  end
+
+  def process_overrides([]), do: []
+
+  def process_overrides(list) when is_list(list) do
+    Enum.map(list, fn {k, v} -> {underscores_to_dashes(k), v} end)
+    |> Enum.into(%{})
+  end
+
+  defp underscores_to_dashes(atom) do
+    atom |> to_string() |> String.replace("_", "-")
+  end
+end

--- a/lib/satie/timespan_list/explode.ex
+++ b/lib/satie/timespan_list/explode.ex
@@ -1,5 +1,7 @@
 defmodule Satie.TimespanList.Explode do
-  @moduledoc false
+  @moduledoc """
+    Helper functions for Satie.TimespanList.explode
+  """
 
   alias Satie.{Timespan, TimespanList}
 

--- a/lib/satie/timespan_list/to_lilypond.ex
+++ b/lib/satie/timespan_list/to_lilypond.ex
@@ -1,5 +1,7 @@
 defmodule Satie.TimespanList.ToLilypond do
-  @moduledoc false
+  @moduledoc """
+    Helper functions for converting a TimespanList to lilypond/postscript output
+  """
 
   @spacer ""
   @for Satie.TimespanList

--- a/test/satie/markup_test.exs
+++ b/test/satie/markup_test.exs
@@ -1,0 +1,208 @@
+defmodule Satie.MarkupTest do
+  use ExUnit.Case, async: true
+  import DescribeFunction
+
+  alias Satie.{Markup, Note}
+
+  describe_function &Markup.new/1 do
+    test "can build a simple text markup" do
+      component =
+        """
+        \\markup {
+          hello
+        }
+        """
+        |> String.trim()
+
+      assert Markup.new("hello") == %Markup{
+               content: "hello",
+               components: [
+                 after: [component]
+               ]
+             }
+    end
+
+    test "more complex nested markup can be built up" do
+      markup =
+        "hello"
+        |> Markup.italic()
+        |> Markup.new()
+
+      component =
+        """
+        \\markup {
+          \\italic {
+            "hello"
+          }
+        }
+        """
+        |> String.trim()
+
+      assert markup == %Markup{
+               content: %{
+                 command: "italic",
+                 content: "hello"
+               },
+               components: [
+                 after: [component]
+               ]
+             }
+    end
+
+    test "some markup can take arguments" do
+      markup =
+        "hello"
+        |> Markup.fontsize(23)
+        |> Markup.new()
+
+      component =
+        """
+        \\markup {
+          \\fontsize #23 {
+            "hello"
+          }
+        }
+        """
+        |> String.trim()
+
+      assert markup == %Markup{
+               content: %{
+                 command: "fontsize",
+                 argument: 23,
+                 overrides: [],
+                 content: "hello"
+               },
+               components: [
+                 after: [component]
+               ]
+             }
+    end
+
+    test "some markup takes overrides" do
+      markup =
+        "hello"
+        |> Markup.box(box_padding: 3, thickness: 5)
+        |> Markup.new()
+
+      component =
+        """
+        \\markup {
+          \\override #'(
+            (box-padding . 3)
+            (thickness . 5)
+          )
+          \\box {
+            "hello"
+          }
+        }
+        """
+        |> String.trim()
+
+      assert markup == %Markup{
+               content: %{
+                 command: "box",
+                 overrides: %{"box-padding" => 3, "thickness" => 5},
+                 content: "hello"
+               },
+               components: [after: [component]]
+             }
+    end
+
+    test "some markup can take a list of contents" do
+      markup =
+        Markup.column([
+          Markup.italic("hello"),
+          Markup.bold("hi")
+        ])
+        |> Markup.new()
+
+      component =
+        """
+        \\markup {
+          \\column {
+            \\italic {
+              "hello"
+            }
+            \\bold {
+              "hi"
+            }
+          }
+        }
+        """
+        |> String.trim()
+
+      assert markup == %Markup{
+               content: %{
+                 command: "column",
+                 content: [
+                   %{command: "italic", content: "hello"},
+                   %{command: "bold", content: "hi"}
+                 ]
+               },
+               components: [after: [component]]
+             }
+    end
+  end
+
+  describe_function &Markup.italic/1 do
+    test "returns the correct data map" do
+      assert Markup.italic("ok") == %{
+               command: "italic",
+               content: "ok"
+             }
+    end
+  end
+
+  describe_function &Markup.fontsize/2 do
+    test "returns the correct data map" do
+      assert Markup.fontsize("ok", 15) == %{
+               command: "fontsize",
+               overrides: [],
+               argument: 15,
+               content: "ok"
+             }
+    end
+  end
+
+  describe_function &Markup.box/2 do
+    test "returns the correct data map" do
+      assert Markup.box("ok") == %{
+               command: "box",
+               overrides: [],
+               content: "ok"
+             }
+
+      assert Markup.box("ok", box_padding: 3) == %{
+               command: "box",
+               overrides: %{
+                 "box-padding" => 3
+               },
+               content: "ok"
+             }
+    end
+  end
+
+  describe "attaching markup to a note" do
+    test "returns the correct lilypond" do
+      markup =
+        "hello"
+        |> Markup.italic()
+        |> Markup.new()
+
+      note =
+        Note.new("c4")
+        |> Satie.attach(markup, direction: :up)
+
+      assert Satie.to_lilypond(note) ==
+               """
+               c4
+                 ^ \\markup {
+                   \\italic {
+                     "hello"
+                   }
+                 }
+               """
+               |> String.trim()
+    end
+  end
+end


### PR DESCRIPTION
- add macros to generate pipeable `Markup` functions based on required
  arguments and optional overrides (with validation)
- add a large number of the supported markup functions, and notes for
  the ones that still need to be worked out
